### PR TITLE
add encoding line

### DIFF
--- a/le_utils/constants/exercises.py
+++ b/le_utils/constants/exercises.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 from gettext import gettext as _
 
 """ Mastery Models """


### PR DESCRIPTION
I generated a kolibri .pex build with the perseus renderer and tried to run it in ubuntu.

It gave this error:

```
SyntaxError:
Non-ASCII character '\xe2' in kolibri/dist/le_utils/constants/exercises.py on line 20, but no encoding declared;
see http://www.python.org/peps/pep-0263.html for details
```

I tried adding this encoding line, but I'm having trouble testing the solution because I don't fully understand how the build process works.
