### PR TITLE
Implemented getlang_by_native_name for easier lookups

### DIFF
--- a/le_utils/constants/languages.py
+++ b/le_utils/constants/languages.py
@@ -59,6 +59,15 @@ def _initialize_language_list():
 
         yield Language(**values)
 
+def _iget(key, lookup_dict):
+    """
+    Case-insensitive search for `key` within keys of `lookup_dict`.
+    """
+    for k, v in lookup_dict.items():
+        if k.lower() == key.lower():
+            return v
+    return None
+
 LANGUAGELIST = list(_initialize_language_list())
 
 _LANGLOOKUP = {l.code: l for l in LANGUAGELIST}
@@ -96,19 +105,57 @@ for lang_name, lang_obj in _LANGUAGE_NAME_LOOKUP.items():
             new_items[simple_name] = lang_obj
 _LANGUAGE_NAME_LOOKUP.update(new_items)
 
-
 def getlang_by_name(name):
     """
     Try to lookup a Language object by name, e.g. 'English', in internal language list.
     Returns None if lookup by language name fails in resources/languagelookup.json.
     """
-    direct_match = _LANGUAGE_NAME_LOOKUP.get(name, None)
+    direct_match = _iget(name, _LANGUAGE_NAME_LOOKUP)
     if direct_match:
         return direct_match
     else:
         simple_name = name.split(',')[0]                 # take part before comma
         simple_name = simple_name.split('(')[0].strip()  # and before any bracket
         return _LANGUAGE_NAME_LOOKUP.get(simple_name, None)
+
+
+
+
+_LANGUAGE_NATIVE_NAME_LOOKUP = {l.native_name: l for l in LANGUAGELIST}
+
+# Enrich _LANGUAGE_NATIVE_NAME_LOOKUP with aliases for list-like names
+new_items = {}
+for lang_native_name, lang_obj in _LANGUAGE_NATIVE_NAME_LOOKUP.items():
+    # Add base native names without modifies in brackets or after comma
+    if ',' in lang_native_name:
+        new_native_names = [n.strip() for n in lang_native_name.split(',')]
+        for new_native_name in new_native_names:
+            simple_native_name = new_native_name.split('(')[0].strip()  # text before any bracket
+            if simple_native_name in _LANGUAGE_NATIVE_NAME_LOOKUP.keys():
+                logger.debug('Skip ' + simple_native_name + ' because it already exisits')
+            else:
+                new_items[simple_native_name] = lang_obj
+    elif '(' in lang_native_name:
+        simple_native_name = lang_native_name.split('(')[0].strip()  # text before any bracket
+        if simple_native_name in _LANGUAGE_NATIVE_NAME_LOOKUP.keys():
+            logger.debug('Skip ' + simple_native_name + ' because it already exisits')
+        else:
+            new_items[simple_native_name] = lang_obj
+_LANGUAGE_NATIVE_NAME_LOOKUP.update(new_items)
+
+def getlang_by_native_name(native_name):
+    """
+    Try to lookup a Language object by native_name, e.g. 'English', in internal language list.
+    Returns None if lookup by language name fails in resources/languagelookup.json.
+    """
+    direct_match = _iget(native_name, _LANGUAGE_NATIVE_NAME_LOOKUP)
+    if direct_match:
+        return direct_match
+    else:
+        simple_native_name = native_name.split(',')[0]                 # take part before comma
+        simple_native_name = simple_native_name.split('(')[0].strip()  # and before any bracket
+        return _LANGUAGE_NATIVE_NAME_LOOKUP.get(simple_native_name, None)
+
 
 
 def getlang_by_alpha2(code):

--- a/tests/test_getlangs.py
+++ b/tests/test_getlangs.py
@@ -110,6 +110,7 @@ def test_list_like_language_names():
 # getlang_by_alpha2 ==> Lookup by two-letter Language code
 ################################################################################
 
+
 def test_known_alpha2_codes():
     lang_obj = languages.getlang_by_alpha2('en')
     assert lang_obj is not None, 'English not found'
@@ -132,5 +133,127 @@ def test_known_alpha2_codes():
 def test_unknown_alpha2_code():
     lang_obj = languages.getlang_by_alpha2('zz')
     assert lang_obj is None, 'Uknown code zz returned non-None'
+
+
+
+
+# getlang_by_native_name ==> Lookup by Language object by native_name
+################################################################################
+
+def test_known_native_names():
+    lang_obj = languages.getlang_by_native_name('English')
+    assert lang_obj is not None, 'English not found'
+    assert lang_obj.code == "en", 'Wrong code'
+    assert lang_obj.name == "English", 'Wrong name'
+    assert lang_obj.native_name == "English", 'Wrong native_name'
+
+    lang_obj = languages.getlang_by_native_name('isiZulu')
+    assert lang_obj is not None, 'Zulu not found'
+    assert lang_obj.code == "zul", 'Wrong internal repr. code'
+    assert lang_obj.name == "Zulu", 'Wrong name'
+    assert lang_obj.native_name == "isiZulu", 'Wrong native_name'
+
+    # NOTE: Currently only support full-name matching so would have to lookup by
+    #       "name, country" to get local language version
+    lang_obj = languages.getlang_by_native_name('Português')
+    assert lang_obj is not None, 'Brazilian Portuguese not found'
+    assert lang_obj.code == "pt", 'Wrong internal repr. code'
+    assert lang_obj.name == "Portuguese", 'Wrong name'
+    assert lang_obj.native_name == "Português", 'Wrong native_name'
+
+    # NOTE: Currently only support full match lookups where multiple language
+    #       specified spearated by semicolons, e.g. "Scottish Gaelic; Gaelic"
+    lang_obj = languages.getlang_by_native_name('Gàidhlig')
+    assert lang_obj is not None, 'Scottish Gaelic; Gaelic not found'
+    assert lang_obj.code == "gd", 'Wrong internal repr. code'
+    assert lang_obj.name == "Scottish Gaelic; Gaelic", 'Wrong name'
+    assert lang_obj.native_name == "Gàidhlig", 'Wrong native_name'
+
+
+def test_unknown_name():
+    lang_obj = languages.getlang_by_native_name('UnknoenNativeLanguage')
+    assert lang_obj is None, 'query for natove_name UnknoenNativeLanguage returned non-None'
+
+def test_language_names_with_modifier_in_bracket():
+    # try to match based on language name (stuff before subcode in brackets)
+    lang_obj = languages.getlang_by_native_name('中文')
+    assert lang_obj is not None, 'Chinese 1 not found'
+    assert lang_obj.code == "zh", 'Wrong internal repr. code'
+    assert lang_obj.name == "Chinese", 'Wrong name'
+    assert lang_obj.native_name == "中文 (Zhōngwén), 汉语, 漢語", 'Wrong native_name'
+    #
+    lang_obj = languages.getlang_by_native_name('汉语')
+    assert lang_obj is not None, 'Chinese 2 not found'
+    assert lang_obj.code == "zh", 'Wrong internal repr. code'
+    assert lang_obj.name == "Chinese", 'Wrong name'
+    assert lang_obj.native_name == "中文 (Zhōngwén), 汉语, 漢語", 'Wrong native_name'
+    #
+    lang_obj = languages.getlang_by_native_name('漢語')
+    assert lang_obj is not None, 'Chinese 3 not found'
+    assert lang_obj.code == "zh", 'Wrong internal repr. code'
+    assert lang_obj.name == "Chinese", 'Wrong name'
+    assert lang_obj.native_name == "中文 (Zhōngwén), 汉语, 漢語", 'Wrong native_name'
+    #
+    lang_obj = languages.getlang_by_native_name('日本語')
+    assert lang_obj is not None, 'Japanese not found'
+    assert lang_obj.code == "ja", 'Wrong internal repr. code'
+    assert lang_obj.name == "Japanese", 'Wrong name'
+    assert lang_obj.native_name == "日本語 (にほんご／にっぽんご)", 'Wrong native_name'
+    #
+    lang_obj = languages.getlang_by_native_name('한국어')
+    assert lang_obj is not None, 'Korean not found'
+    assert lang_obj.code == "ko", 'Wrong internal repr. code'
+    assert lang_obj.name == "Korean", 'Wrong name'
+    assert lang_obj.native_name == "한국어 (韓國語), 조선말 (朝鮮語)", 'Wrong native_name'
+    #
+    lang_obj = languages.getlang_by_native_name('조선말')
+    assert lang_obj is not None, 'Korean not found'
+    assert lang_obj.code == "ko", 'Wrong internal repr. code'
+    assert lang_obj.name == "Korean", 'Wrong name'
+    assert lang_obj.native_name == "한국어 (韓國語), 조선말 (朝鮮語)", 'Wrong native_name'
+
+
+def test_list_like_language_native_names():
+    lang_obj = languages.getlang_by_native_name('Iñupiaq')
+    assert lang_obj is not None, 'Inupiaq not found'
+    assert lang_obj.code == "ik", 'Wrong internal repr. code'
+    assert lang_obj.name == "Inupiaq", 'Wrong name'
+    assert lang_obj.native_name == "Iñupiaq, Iñupiatun", 'Wrong native_name'
+    #
+    lang_obj = languages.getlang_by_native_name('Iñupiatun')
+    assert lang_obj is not None, 'Inupiaq not found'
+    assert lang_obj.code == "ik", 'Wrong internal repr. code'
+    assert lang_obj.name == "Inupiaq", 'Wrong name'
+    assert lang_obj.native_name == "Iñupiaq, Iñupiatun", 'Wrong native_name'
+
+
+
+@pytest.fixture
+def african_languages_list():
+    return ['Sesotho', 'isiXhosa', 'isiZulu', 'isiNdebele', 'Setswana', 'Siswati', 'Xitsonga']
+
+def test_african_languages(african_languages_list):
+    missing_names = []
+    for native_name in african_languages_list:
+        lang_obj = languages.getlang_by_native_name(native_name)
+        if lang_obj is None:
+            missing_names.append(native_name)
+    assert missing_names == [], 'Languages with native_names missing: ' + str(missing_names)
+
+
+
+@pytest.fixture
+def african_languages_list2():
+    return ['Sepedi', 'Tshivenda']
+
+@pytest.mark.skip('These languages are not in json data yet')
+def test_african_languages2(african_languages_list2):
+    missing_names = []
+    for native_name in african_languages_list2:
+        lang_obj = languages.getlang_by_native_name(native_name)
+        if lang_obj is None:
+            missing_names.append(native_name)
+    print('missing_names=', missing_names)
+    assert missing_names == [], 'Languages with native_names missing: ' + str(missing_names)
 
 


### PR DESCRIPTION
While looking at this site http://nalibali.org/story-library/multilingual-stories
it became apparent we might need a lookup function for languages by native name.

This PR implements this. See tests for example usage.


Currently only two languages of the ones on nalibali.org are missing so we should add them to our internal json DB: `[u'Sepedi', u'Tshivenda']`
see https://en.wikipedia.org/wiki/Northern_Sotho_language
https://en.wikipedia.org/wiki/Venda_language
already have Venda but the native name is different, so we could add it after a comma.

Modify:
```
  "ve":{
    "name":"Venda",
    "native_name":"Tshivenḓa"
  },
```
To:
```
  "ve":{
    "name":"Venda",
    "native_name":"Tshivenḓa, Tshivenda"
  },
```
