### PR TITLE
fix wrong default Spanish lookup by name

### DIFF
--- a/le_utils/constants/languages.py
+++ b/le_utils/constants/languages.py
@@ -108,7 +108,7 @@ for lang_name, lang_obj in _LANGUAGE_NAME_LOOKUP.items():
     if ';' in lang_name:
         new_names = [n.strip() for n in lang_name.split(';')]
         for new_name in new_names:
-            if new_name in _LANGUAGE_NAME_LOOKUP.keys():
+            if new_name in _LANGUAGE_NAME_LOOKUP.keys() or new_name in new_items:
                 logger.debug('Skip ' + new_name + ' because it already exisits')
             else:
                 new_items[new_name] = lang_obj
@@ -116,7 +116,7 @@ for lang_name, lang_obj in _LANGUAGE_NAME_LOOKUP.items():
     elif '(' in lang_name or ',' in lang_name:
         simple_name = lang_name.split(',')[0]            # take part before comma
         simple_name = simple_name.split('(')[0].strip()  # and before any bracket
-        if simple_name in _LANGUAGE_NAME_LOOKUP.keys():
+        if simple_name in _LANGUAGE_NAME_LOOKUP.keys() or new_name in new_items:
             logger.debug('Skip ' + simple_name + ' because it already exisits')
         else:
             new_items[simple_name] = lang_obj
@@ -148,17 +148,18 @@ for lang_native_name, lang_obj in _LANGUAGE_NATIVE_NAME_LOOKUP.items():
         new_native_names = [n.strip() for n in lang_native_name.split(',')]
         for new_native_name in new_native_names:
             simple_native_name = new_native_name.split('(')[0].strip()  # text before any bracket
-            if simple_native_name in _LANGUAGE_NATIVE_NAME_LOOKUP.keys():
+            if simple_native_name in _LANGUAGE_NATIVE_NAME_LOOKUP.keys() or new_native_name in new_items:
                 logger.debug('Skip ' + simple_native_name + ' because it already exisits')
             else:
                 new_items[simple_native_name] = lang_obj
     elif '(' in lang_native_name:
         simple_native_name = lang_native_name.split('(')[0].strip()  # text before any bracket
-        if simple_native_name in _LANGUAGE_NATIVE_NAME_LOOKUP.keys():
+        if simple_native_name in _LANGUAGE_NATIVE_NAME_LOOKUP.keys() or simple_native_name in new_items:
             logger.debug('Skip ' + simple_native_name + ' because it already exisits')
         else:
             new_items[simple_native_name] = lang_obj
 _LANGUAGE_NATIVE_NAME_LOOKUP.update(new_items)
+
 
 def getlang_by_native_name(native_name):
     """

--- a/le_utils/resources/languagelookup.json
+++ b/le_utils/resources/languagelookup.json
@@ -596,8 +596,8 @@
     "native_name":"Sesotho"
   },
   "es":{
-    "name":"Spanish; Castilian",
-    "native_name":"Español, Castellano",
+    "name":"Spanish",
+    "native_name":"Español",
     "ka_name":"espanol"
   },
   "su":{
@@ -742,8 +742,8 @@
     "native_name":"Argh! Pirates!"
   },
   "es-ES":{
-    "name":"Spanish, Spain",
-    "native_name":"Español"
+    "name":"Spanish, Spain; Castilian",
+    "native_name":"Español (España), Castellano"
   },
   "fil":{
     "name":"Filipino",
@@ -755,11 +755,11 @@
   },
   "pt-BR":{
     "name":"Portuguese, Brazil",
-    "native_name":"Português, Brasil"
+    "native_name":"Português (Brasil)"
   },
   "pt-PT":{
     "name":"Portuguese, Portugal",
-    "native_name":"Português",
+    "native_name":"Português (Portugal)",
     "ka_name":"portugal portugues"
   },
   "sr-CS":{
@@ -808,23 +808,23 @@
   },
   "en-GB":{
     "name":"English, Britain",
-    "native_name":"English, Britain"
+    "native_name":"British English"
   },
   "es-AR":{
     "name":"Spanish, Argentina",
-    "native_name":"Español, Argentina"
+    "native_name":"Español (Argentina)"
   },
   "es-MX":{
     "name":"Spanish, Mexico",
-    "native_name":"Español, Mexico"
+    "native_name":"Español (Mexico)"
   },
   "es-NI":{
     "name":"Spanish, Nicaragua",
-    "native_name":""
+    "native_name":"Español (Nicaragua)"
   },
   "fr-CA":{
     "name":"French, Canada",
-    "native_name":"Français, canada"
+    "native_name":"Français (Canada)"
   },
   "ful":{
     "name":"Fula",

--- a/tests/test_getlangs.py
+++ b/tests/test_getlangs.py
@@ -19,7 +19,7 @@ def test_known_codes():
     lang_obj = languages.getlang('pt-BR')
     assert lang_obj is not None, 'Brazilian Portuguese not found'
     assert lang_obj.name == "Portuguese, Brazil", 'Wrong name'
-    assert lang_obj.native_name == "Português, Brasil", 'Wrong native_name'
+    assert lang_obj.native_name == "Português (Brasil)", 'Wrong native_name'
 
     lang_obj = languages.getlang('zul')
     assert lang_obj is not None, 'Zulu not found'
@@ -55,7 +55,7 @@ def test_known_names():
     assert lang_obj is not None, 'Brazilian Portuguese not found'
     assert lang_obj.code == "pt-BR", 'Wrong internal repr. code'
     assert lang_obj.name == "Portuguese, Brazil", 'Wrong name'
-    assert lang_obj.native_name == "Português, Brasil", 'Wrong native_name'
+    assert lang_obj.native_name == "Português (Brasil)", 'Wrong native_name'
 
     # NOTE: Currently only support full match lookups where multiple language
     #       specified spearated by semicolons, e.g. "Scottish Gaelic; Gaelic"
@@ -110,7 +110,6 @@ def test_list_like_language_names():
 # getlang_by_alpha2 ==> Lookup by two-letter Language code
 ################################################################################
 
-
 def test_known_alpha2_codes():
     lang_obj = languages.getlang_by_alpha2('en')
     assert lang_obj is not None, 'English not found'
@@ -156,7 +155,7 @@ def test_known_native_names():
     # NOTE: Currently only support full-name matching so would have to lookup by
     #       "name, country" to get local language version
     lang_obj = languages.getlang_by_native_name('Português')
-    assert lang_obj is not None, 'Brazilian Portuguese not found'
+    assert lang_obj is not None, 'Portuguese not found'
     assert lang_obj.code == "pt", 'Wrong internal repr. code'
     assert lang_obj.name == "Portuguese", 'Wrong name'
     assert lang_obj.native_name == "Português", 'Wrong native_name'
@@ -230,7 +229,8 @@ def test_list_like_language_native_names():
 
 @pytest.fixture
 def african_languages_list():
-    return ['Sesotho', 'isiXhosa', 'isiZulu', 'isiNdebele', 'Setswana', 'Siswati', 'Xitsonga']
+    return ['Sesotho', 'isiXhosa', 'isiZulu', 'isiNdebele', 'Setswana', 'Siswati',
+            'Xitsonga', 'Sepedi', 'Tshivenda']
 
 def test_african_languages(african_languages_list):
     missing_names = []
@@ -239,20 +239,4 @@ def test_african_languages(african_languages_list):
         if lang_obj is None:
             missing_names.append(native_name)
     assert missing_names == [], 'Languages with native_names missing: ' + str(missing_names)
-
-
-
-@pytest.fixture
-def african_languages_list2():
-    return ['Sepedi', 'Tshivenda']
-
-def test_african_languages2(african_languages_list2):
-    missing_names = []
-    for native_name in african_languages_list2:
-        lang_obj = languages.getlang_by_native_name(native_name)
-        if lang_obj is None:
-            missing_names.append(native_name)
-    print('missing_names=', missing_names)
-    assert missing_names == [], 'Languages with native_names missing: ' + str(missing_names)
-
 


### PR DESCRIPTION
Before this PR, looking for Spanish by name was retuning Nicaraguan

```
>>> from le_utils.constants.languages import getlang, getlang_by_name, getlang_by_native_name
>>> lang_obj = getlang_by_name('Spanish')
>>> lang_obj.code
'es-NI'
```
There was a bug in the "enrichment" logic (edge case only applies to Spanish) that used the last occurence of the string.


After this PR, the un-localized Spanish gets processed first and so becomes the default:
```
>>> from le_utils.constants.languages import getlang, getlang_by_name, getlang_by_native_name
>>> lang_obj = getlang_by_name('Spanish')
>>> lang_obj.code
'es'
```

The second commit also fixes some inconsistensies in the `native_name` attributes. I enforced the convention that commas separate sifferent native names, and extra attributes in brackets.

