### PR TITLE
Added 3-letter internal language codes for Scots and Rusyn langs

### DIFF
--- a/le_utils/resources/languagelookup.json
+++ b/le_utils/resources/languagelookup.json
@@ -570,6 +570,10 @@
     "name":"Scottish Gaelic; Gaelic",
     "native_name":"Gàidhlig"
   },
+  "sco":{
+    "name":"Scots",
+    "native_name":"Scots"
+  },
   "sn":{
     "name":"Shona",
     "native_name":"chiShona"
@@ -684,6 +688,10 @@
     "name":"Ukrainian",
     "native_name":"українська",
     "ka_name":"ukranian"
+  },
+  "rue":{
+    "name":"Rusyn",
+    "native_name":"русиньскый язык"
   },
   "ur":{
     "name":"Urdu",


### PR DESCRIPTION
sco = Scots
https://www.ethnologue.com/language/sco

rue = Rusyn
https://www.ethnologue.com/language/rue