### PR TITLE
keep file_formats.py in sync with formatlookup.json

### DIFF
--- a/le_utils/constants/file_formats.py
+++ b/le_utils/constants/file_formats.py
@@ -14,8 +14,9 @@ MP4_MIMETYPE = "video/mp4"
 # constants for Subtitle format
 VTT = "vtt"
 VTT_MIMETYPE = ".vtt"
-SRT = "srt"
-SRT_MIMETYPE = "text/srt"
+# SRT support is planned but not yet implemented
+# SRT = "srt"
+# SRT_MIMETYPE = "text/srt"
 
 # constants for Audio format
 MP3 = "mp3"
@@ -59,7 +60,7 @@ choices = (
     (MP4, _("MP4 Video")),
 
     (VTT, _("VTT Subtitle")),
-    (SRT, _("SRT Subtitle")),
+    # (SRT, _("SRT Subtitle")),
 
     (MP3, _("MP3 Audio")),
 
@@ -73,6 +74,8 @@ choices = (
     (SVG, _("SVG Image")),
 
     (PERSEUS, _("Perseus Exercise")),
+
+    (GRAPHIE, _("Graphie Exercise")),
 
     (HTML5, _("HTML5 Zip")),
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import pytest
+import json
+import pkgutil
+
+from le_utils.constants import file_formats
+def test_file_format_extensions_are_synced():
+    formatlookup = json.loads(pkgutil.get_data('le_utils', 'resources/formatlookup.json').decode('utf-8'))
+
+    exts_formatlookup = set(dict(formatlookup).keys())
+    exts_file_formats = set(dict(file_formats.choices).keys())
+
+    assert exts_formatlookup == exts_file_formats
+


### PR DESCRIPTION
I synced these up and added a test to ensure that all the file extensions listed in `file_formats.choices` are also listed in `formatlookup.json`.