### PR TITLE
remove reference to file_formats.SRT in file_types

### DIFF
--- a/le_utils/constants/file_types.py
+++ b/le_utils/constants/file_types.py
@@ -35,5 +35,5 @@ MAPPING = {
     #
     # formats SubtitleFile
     file_formats.VTT: SUBTITLES,
-    file_formats.SRT: SUBTITLES,
+    # file_formats.SRT: SUBTITLES,
 }


### PR DESCRIPTION
rm reference, otherwise trying to import `file_types` causes this error:
```
Traceback (most recent call last):
  File "./chef.py", line 41, in <module>
    from le_utils.constants import content_kinds, file_types, licenses
  File "/data/sushi-chef-pradigi/venv/lib/python3.5/site-packages/le_utils/constants/file_types.py", line 38, in <module>
    file_formats.SRT: SUBTITLES,
AttributeError: module 'le_utils.constants.file_formats' has no attribute 'SRT'
```