### PR TITLE
Add convertible_formats to format_presets json list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ celerybeat-schedule
 
 # virtualenv
 venv/
+venv2/
 ENV/
 
 # Spyder project settings

--- a/le_utils/constants/content_kinds.py
+++ b/le_utils/constants/content_kinds.py
@@ -35,7 +35,7 @@ MAPPING = {
 }
 
 
-class Kind(namedtuple("Kind", ["id", "name"])):
+class Kind(namedtuple("Kind", ["id", "name", "convertible_formats"])):
     pass
 
 def generate_list(constantlist):

--- a/le_utils/constants/content_kinds.py
+++ b/le_utils/constants/content_kinds.py
@@ -35,7 +35,7 @@ MAPPING = {
 }
 
 
-class Kind(namedtuple("Kind", ["id", "name", "convertible_formats"])):
+class Kind(namedtuple("Kind", ["id", "name"])):
     pass
 
 def generate_list(constantlist):

--- a/le_utils/constants/file_formats.py
+++ b/le_utils/constants/file_formats.py
@@ -21,13 +21,13 @@ FLV = "flv"
 
 # constants for Subtitle format
 VTT = "vtt"
-VTT_MIMETYPE = ".vtt"
+VTT_MIMETYPE = "text/vtt"
 # constants for formats convertible to VTT
 SRT = "srt"
 
 # constants for Audio format
 MP3 = "mp3"
-MP3_MIMETYPE = ".mp3"
+MP3_MIMETYPE = "audio/mpeg"
 
 # constants for Document format
 PDF = "pdf"
@@ -56,7 +56,7 @@ PERSEUS_MIMETYPE = "application/perseus+zip"
 
 # constants for HTML5 zip format
 HTML5 = "zip"
-HTML5_MIMETYPE = ".zip"
+HTML5_MIMETYPE = "application/zip"
 
 # constants for ePub format
 EPUB = "epub"
@@ -88,7 +88,7 @@ choices = (
     (EPUB, _("ePub Document")),
 )
 
-class Format(namedtuple("Format", ["id", "mimetype", "convertible_formats"])):
+class Format(namedtuple("Format", ["id", "mimetype"])):
     pass
 
 def generate_list(constantlist):

--- a/le_utils/constants/file_formats.py
+++ b/le_utils/constants/file_formats.py
@@ -15,8 +15,8 @@ MP4_MIMETYPE = "video/mp4"
 VTT = "vtt"
 VTT_MIMETYPE = ".vtt"
 # SRT support is planned but not yet implemented
-# SRT = "srt"
-# SRT_MIMETYPE = "text/srt"
+SRT = "srt"
+SRT_MIMETYPE = "text/srt"
 
 # constants for Audio format
 MP3 = "mp3"
@@ -60,7 +60,7 @@ choices = (
     (MP4, _("MP4 Video")),
 
     (VTT, _("VTT Subtitle")),
-    # (SRT, _("SRT Subtitle")),
+    (SRT, _("SRT Subtitle")),
 
     (MP3, _("MP3 Audio")),
 

--- a/le_utils/constants/file_formats.py
+++ b/le_utils/constants/file_formats.py
@@ -10,13 +10,20 @@ from gettext import gettext as _
 # constants for Video format
 MP4 = "mp4"
 MP4_MIMETYPE = "video/mp4"
+# constants for video formats converitble to mp4
+AVI = "avi"
+MOV = "mov"
+MPG = "mpg"
+WMV = "wmv"
+WEBM = "webm"
+MKV = "mkv"
+FLV = "flv"
 
 # constants for Subtitle format
 VTT = "vtt"
 VTT_MIMETYPE = ".vtt"
-# SRT support is planned but not yet implemented
+# constants for formats convertible to VTT
 SRT = "srt"
-SRT_MIMETYPE = "text/srt"
 
 # constants for Audio format
 MP3 = "mp3"
@@ -60,7 +67,6 @@ choices = (
     (MP4, _("MP4 Video")),
 
     (VTT, _("VTT Subtitle")),
-    (SRT, _("SRT Subtitle")),
 
     (MP3, _("MP3 Audio")),
 
@@ -82,7 +88,7 @@ choices = (
     (EPUB, _("ePub Document")),
 )
 
-class Format(namedtuple("Format", ["id", "mimetype"])):
+class Format(namedtuple("Format", ["id", "mimetype", "convertible_formats"])):
     pass
 
 def generate_list(constantlist):

--- a/le_utils/constants/file_types.py
+++ b/le_utils/constants/file_types.py
@@ -35,5 +35,4 @@ MAPPING = {
     #
     # formats SubtitleFile
     file_formats.VTT: SUBTITLES,
-    file_formats.SRT: SUBTITLES,
 }

--- a/le_utils/constants/format_presets.py
+++ b/le_utils/constants/format_presets.py
@@ -58,7 +58,7 @@ HTML5_DEPENDENCY_ZIP_READABLE = "HTML5 Dependency (Zip format)"
 choices = (
     (VIDEO_HIGH_RES, _(VIDEO_HIGH_RES_READABLE)),
     (VIDEO_LOW_RES, _(VIDEO_LOW_RES_READABLE)),
-    (VIDEO_VECTOR, _(VIDEO_VECTOR_READABLE)),
+    # (VIDEO_VECTOR, _(VIDEO_VECTOR_READABLE)),  # doesn't exist yet so took out
     (VIDEO_THUMBNAIL, _(VIDEO_THUMBNAIL_READABLE)),
     (VIDEO_SUBTITLE, _(VIDEO_SUBTITLE_READABLE)),
     (VIDEO_DEPENDENCY, _(VIDEO_DEPENDENCY_READABLE)),
@@ -86,7 +86,17 @@ choices = (
 
 class Preset(
     namedtuple("Preset", [
-            "id", "readable_name", "multi_language", "supplementary", "thumbnail", "subtitle", "display", "order", "kind", "allowed_formats"
+            "id",
+            "readable_name",
+            "multi_language",
+            "supplementary",
+            "thumbnail",
+            "subtitle",
+            "display",
+            "order",
+            "kind",
+            "allowed_formats",
+            "convertible_formats"
         ])):
     pass
 

--- a/le_utils/resources/formatlookup.json
+++ b/le_utils/resources/formatlookup.json
@@ -5,6 +5,9 @@
 	"vtt": {
 		"mimetype": ".vtt"
 	},
+  "srt": {
+		"mimetype": ".srt"
+	},
 	"pdf": {
 		"mimetype": "application/pdf"
 	},

--- a/le_utils/resources/formatlookup.json
+++ b/le_utils/resources/formatlookup.json
@@ -1,58 +1,44 @@
 {
 	"mp4": {
-		"mimetype": "video/mp4",
-		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
+		"mimetype": "video/mp4"
 	},
 	"vtt": {
-		"mimetype": ".vtt",
-		"convertible_formats": ["srt"]
+		"mimetype": "text/vtt"
 	},
 	"pdf": {
-		"mimetype": "application/pdf",
-		"convertible_formats": []
+		"mimetype": "application/pdf"
 	},
 	"epub": {
-		"mimetype": "application/epub+zip",
-		"convertible_formats": []
+		"mimetype": "application/epub+zip"
 	},
 	"mp3": {
-		"mimetype": ".mp3",
-		"convertible_formats": []
+		"mimetype": "audio/mpeg"
 	},
 	"jpg": {
-		"mimetype": "image/jpeg",
-		"convertible_formats": []
+		"mimetype": "image/jpeg"
 	},
 	"jpeg": {
-		"mimetype": "image/jpeg",
-		"convertible_formats": []
+		"mimetype": "image/jpeg"
 	},
 	"png": {
-		"mimetype": "image/png",
-		"convertible_formats": []
+		"mimetype": "image/png"
 	},
 	"gif": {
-		"mimetype": "image/gif",
-		"convertible_formats": []
+		"mimetype": "image/gif"
 	},
 	"json": {
-		"mimetype": "application/json",
-		"convertible_formats": []
+		"mimetype": "application/json"
 	},
 	"svg": {
-		"mimetype": "image/svg",
-		"convertible_formats": []
+		"mimetype": "image/svg"
 	},
 	"graphie": {
-		"mimetype": ".graphie",
-		"convertible_formats": []
+		"mimetype": ".graphie"
 	},
 	"perseus": {
-		"mimetype": "application/perseus+zip",
-		"convertible_formats": []
+		"mimetype": "application/perseus+zip"
 	},
 	"zip": {
-		"mimetype": ".zip",
-		"convertible_formats": []
+		"mimetype": "application/zip"
 	}
 }

--- a/le_utils/resources/formatlookup.json
+++ b/le_utils/resources/formatlookup.json
@@ -1,47 +1,58 @@
 {
 	"mp4": {
-		"mimetype": "video/mp4"
+		"mimetype": "video/mp4",
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
 	},
 	"vtt": {
-		"mimetype": ".vtt"
-	},
-  "srt": {
-		"mimetype": ".srt"
+		"mimetype": ".vtt",
+		"convertible_formats": ["srt"]
 	},
 	"pdf": {
-		"mimetype": "application/pdf"
+		"mimetype": "application/pdf",
+		"convertible_formats": []
 	},
 	"epub": {
-		"mimetype": "application/epub+zip"
+		"mimetype": "application/epub+zip",
+		"convertible_formats": []
 	},
 	"mp3": {
-		"mimetype": ".mp3"
+		"mimetype": ".mp3",
+		"convertible_formats": []
 	},
 	"jpg": {
-		"mimetype": "image/jpeg"
+		"mimetype": "image/jpeg",
+		"convertible_formats": []
 	},
 	"jpeg": {
-		"mimetype": "image/jpeg"
+		"mimetype": "image/jpeg",
+		"convertible_formats": []
 	},
 	"png": {
-		"mimetype": "image/png"
+		"mimetype": "image/png",
+		"convertible_formats": []
 	},
 	"gif": {
-		"mimetype": "image/gif"
+		"mimetype": "image/gif",
+		"convertible_formats": []
 	},
 	"json": {
-		"mimetype": "application/json"
+		"mimetype": "application/json",
+		"convertible_formats": []
 	},
 	"svg": {
-		"mimetype": "image/svg"
+		"mimetype": "image/svg",
+		"convertible_formats": []
 	},
 	"graphie": {
-		"mimetype": ".graphie"
+		"mimetype": ".graphie",
+		"convertible_formats": []
 	},
 	"perseus": {
-		"mimetype": "application/perseus+zip"
+		"mimetype": "application/perseus+zip",
+		"convertible_formats": []
 	},
 	"zip": {
-		"mimetype": ".zip"
+		"mimetype": ".zip",
+		"convertible_formats": []
 	}
 }

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -52,7 +52,7 @@
 		"display": true,
 		"order": 4,
 		"kind": "video",
-		"allowed_formats": ["vtt" ]
+		"allowed_formats": ["vtt"]
 	},
 	"audio": {
 		"readable_name": "Audio",

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -52,7 +52,7 @@
 		"display": true,
 		"order": 4,
 		"kind": "video",
-		"allowed_formats": ["vtt", "srt"]
+		"allowed_formats": ["vtt" ]
 	},
 	"audio": {
 		"readable_name": "Audio",

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -8,7 +8,8 @@
 		"display": true,
 		"order": 1,
 		"kind": "video",
-		"allowed_formats": ["mp4"]
+		"allowed_formats": ["mp4"],
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
 	},
 	"low_res_video": {
 		"readable_name": "Low Resolution",
@@ -19,7 +20,8 @@
 		"display": true,
 		"order": 2,
 		"kind": "video",
-		"allowed_formats": ["mp4"]
+		"allowed_formats": ["mp4"],
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
 	},
   "video_dependency": {
 		"readable_name": "Video Dependency",
@@ -30,7 +32,8 @@
 		"display": false,
 		"order": 3,
 		"kind": "video",
-		"allowed_formats": ["mp4"]
+		"allowed_formats": ["mp4"],
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
 	},
 	"video_thumbnail": {
 		"readable_name": "Thumbnail",
@@ -41,7 +44,8 @@
 		"display": true,
 		"order": 3,
 		"kind": "video",
-		"allowed_formats": ["png", "jpg", "jpeg"]
+		"allowed_formats": ["png", "jpg", "jpeg"],
+		"convertible_formats": []
 	},
 	"video_subtitle": {
 		"readable_name": "Subtitle",
@@ -52,7 +56,8 @@
 		"display": true,
 		"order": 4,
 		"kind": "video",
-		"allowed_formats": ["vtt"]
+		"allowed_formats": ["vtt"],
+		"convertible_formats": ["srt"]
 	},
 	"audio": {
 		"readable_name": "Audio",
@@ -63,7 +68,8 @@
 		"display": true,
 		"order": 1,
 		"kind": "audio",
-		"allowed_formats": ["mp3"]
+		"allowed_formats": ["mp3"],
+		"convertible_formats": ["wav", "m4a", "aac", "ogg"]
 	},
 	"audio_thumbnail": {
 		"readable_name": "Thumbnail",
@@ -74,7 +80,8 @@
 		"display": true,
 		"order": 2,
 		"kind": "audio",
-		"allowed_formats": ["png", "jpg", "jpeg"]
+		"allowed_formats": ["png", "jpg", "jpeg"],
+		"convertible_formats": []
 	},
 	"epub": {
 		"readable_name": "ePub Document",
@@ -85,7 +92,8 @@
 		"display": true,
 		"order": 1,
 		"kind": "document",
-		"allowed_formats": ["epub"]
+		"allowed_formats": ["epub"],
+		"convertible_formats": []
 	},
 	"document": {
 		"readable_name": "Document",
@@ -96,7 +104,8 @@
 		"display": true,
 		"order": 2,
 		"kind": "document",
-		"allowed_formats": ["pdf"]
+		"allowed_formats": ["pdf"],
+		"convertible_formats": []
 	},
 	"document_thumbnail": {
 		"readable_name": "Thumbnail",
@@ -107,7 +116,8 @@
 		"display": true,
 		"order": 2,
 		"kind": "document",
-		"allowed_formats": ["png", "jpg", "jpeg"]
+		"allowed_formats": ["png", "jpg", "jpeg"],
+		"convertible_formats": []
 	},
 	"exercise": {
 		"readable_name": "Exercise",
@@ -118,7 +128,8 @@
 		"display": false,
 		"order": 1,
 		"kind": "exercise",
-		"allowed_formats": ["perseus"]
+		"allowed_formats": ["perseus"],
+		"convertible_formats": []
 	},
 	"exercise_thumbnail": {
 		"readable_name": "Thumbnail",
@@ -129,7 +140,8 @@
 		"display": true,
 		"order": 2,
 		"kind": "exercise",
-		"allowed_formats": ["png", "jpg", "jpeg"]
+		"allowed_formats": ["png", "jpg", "jpeg"],
+		"convertible_formats": []
 	},
 	"exercise_image": {
 		"readable_name": "Exercise Image",
@@ -140,7 +152,8 @@
 		"display": false,
 		"order": 3,
 		"kind": "exercise",
-		"allowed_formats": ["png", "jpg", "jpeg", "gif", "svg"]
+		"allowed_formats": ["png", "jpg", "jpeg", "gif", "svg"],
+		"convertible_formats": []
 	},
 	"exercise_graphie": {
 		"readable_name": "Exercise Graphie",
@@ -151,7 +164,8 @@
 		"display": false,
 		"order": 4,
 		"kind": "exercise",
-		"allowed_formats": ["svg", "json", "graphie"]
+		"allowed_formats": ["svg", "json", "graphie"],
+		"convertible_formats": []
 	},
 	"channel_thumbnail": {
 		"readable_name": "Channel Thumbnail",
@@ -162,7 +176,8 @@
 		"display": true,
 		"order": 0,
 		"kind": null,
-		"allowed_formats": ["png", "jpg", "jpeg"]
+		"allowed_formats": ["png", "jpg", "jpeg"],
+		"convertible_formats": []
 	},
 	"topic_thumbnail": {
 		"readable_name": "Thumbnail",
@@ -173,7 +188,8 @@
 		"display": true,
 		"order": 1,
 		"kind": "topic",
-		"allowed_formats": ["png", "jpg", "jpeg"]
+		"allowed_formats": ["png", "jpg", "jpeg"],
+		"convertible_formats": []
 	},
 	"html5_zip": {
 		"readable_name": "HTML5 Zip",
@@ -184,7 +200,8 @@
 		"display": true,
 		"order": 1,
 		"kind": "html5",
-		"allowed_formats": ["zip"]
+		"allowed_formats": ["zip"],
+		"convertible_formats": []
 	},
   "html5_dependency": {
 		"readable_name": "HTML5 Zip Dependency",
@@ -195,7 +212,8 @@
 		"display": false,
 		"order": 2,
 		"kind": "html5",
-		"allowed_formats": ["zip"]
+		"allowed_formats": ["zip"],
+		"convertible_formats": []
 	},
 	"html5_thumbnail": {
 		"readable_name": "HTML5 Thumbnail",
@@ -206,6 +224,7 @@
 		"display": true,
 		"order": 2,
 		"kind": "html5",
-		"allowed_formats": ["png", "jpg", "jpeg"]
+		"allowed_formats": ["png", "jpg", "jpeg"],
+		"convertible_formats": []
 	}
 }

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -9,7 +9,7 @@
 		"order": 1,
 		"kind": "video",
 		"allowed_formats": ["mp4"],
-		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv"]
 	},
 	"low_res_video": {
 		"readable_name": "Low Resolution",
@@ -21,7 +21,7 @@
 		"order": 2,
 		"kind": "video",
 		"allowed_formats": ["mp4"],
-		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv"]
 	},
   "video_dependency": {
 		"readable_name": "Video Dependency",
@@ -33,7 +33,7 @@
 		"order": 3,
 		"kind": "video",
 		"allowed_formats": ["mp4"],
-		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv"]
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv"]
 	},
 	"video_thumbnail": {
 		"readable_name": "Thumbnail",

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -52,7 +52,7 @@
 		"display": true,
 		"order": 4,
 		"kind": "video",
-		"allowed_formats": ["vtt"]
+		"allowed_formats": ["vtt", "srt"]
 	},
 	"audio": {
 		"readable_name": "Audio",

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -5,6 +5,8 @@ import json
 import pkgutil
 
 from le_utils.constants import file_formats
+
+
 def test_file_format_extensions_are_synced():
     formatlookup = json.loads(pkgutil.get_data('le_utils', 'resources/formatlookup.json').decode('utf-8'))
 
@@ -13,3 +15,6 @@ def test_file_format_extensions_are_synced():
 
     assert exts_formatlookup == exts_file_formats
 
+
+def test_FORMATLIST_exists():
+    assert file_formats.FORMATLIST, 'FORMATLIST did not genereate properly'

--- a/tests/test_kinds.py
+++ b/tests/test_kinds.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import pytest
+import json
+import pkgutil
+
+from le_utils.constants import content_kinds
+
+def test_content_kind_extensions_are_synced():
+    kindlookup = json.loads(pkgutil.get_data('le_utils', 'resources/kindlookup.json').decode('utf-8'))
+    kinds_json = set(dict(kindlookup).keys())
+    kinds_py = set(dict(content_kinds.choices).keys())
+    assert kinds_json == kinds_py
+
+def test_KINDLIST_exists():
+    assert content_kinds.KINDLIST, 'KINDLIST did not genereate properly'

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import pytest
+import json
+import pkgutil
+
+from le_utils.constants import format_presets
+
+
+def test_file_format_extensions_are_synced():
+    presetlookup = json.loads(pkgutil.get_data('le_utils', 'resources/presetlookup.json').decode('utf-8'))
+    presets_json = set(dict(presetlookup).keys())
+    presets_python = set(dict(format_presets.choices).keys())
+    assert presets_json == presets_python
+
+
+def test_PRESETLIST_exists():
+    assert format_presets.PRESETLIST, 'PRESETLIST did not genereate properly'


### PR DESCRIPTION
This is needed to support the two SRT-->VTT conversion PRs:

https://github.com/learningequality/pressurecooker/pull/21
and https://github.com/learningequality/ricecooker/pull/189



The new `convertible_formats` attribute added to the file formats lookup json made me a bit worried that this would cause an error on Studio:
https://github.com/learningequality/studio/blob/develop/contentcuration/contentcuration/management/commands/loadconstants.py#L205-L206
but apparently no, Django models will let you set arbitrary fields on them that don't exist:

```
In [1]: from contentcuration.models import FileFormat
In [7]: ffobj = FileFormat.objects.all()[0]
In [8]: ffobj.__dict__
{'_state': <django.db.models.base.ModelState at 0x10dbb5dd0>,
 'extension': u'graphie',
 'mimetype': u'.graphie'}

In [9]: ffobj.anything_you_want = 'is possible with Django'       # < < NO ERROR

In [10]: ffobj.__dict__
{'_state': <django.db.models.base.ModelState at 0x10dbb5dd0>,
 'anything_you_want': 'is possible',
 'extension': u'graphie',
 'mimetype': u'.graphie'}
```
