### PR TITLE
Put back dot-ext instead of canonical mimetypes

### DIFF
--- a/le_utils/constants/file_formats.py
+++ b/le_utils/constants/file_formats.py
@@ -21,13 +21,13 @@ FLV = "flv"
 
 # constants for Subtitle format
 VTT = "vtt"
-VTT_MIMETYPE = "text/vtt"
+VTT_MIMETYPE = ".vtt"
 # constants for formats convertible to VTT
 SRT = "srt"
 
 # constants for Audio format
 MP3 = "mp3"
-MP3_MIMETYPE = "audio/mpeg"
+MP3_MIMETYPE = ".mp3"
 
 # constants for Document format
 PDF = "pdf"
@@ -56,7 +56,7 @@ PERSEUS_MIMETYPE = "application/perseus+zip"
 
 # constants for HTML5 zip format
 HTML5 = "zip"
-HTML5_MIMETYPE = "application/zip"
+HTML5_MIMETYPE = ".zip"
 
 # constants for ePub format
 EPUB = "epub"

--- a/le_utils/resources/formatlookup.json
+++ b/le_utils/resources/formatlookup.json
@@ -3,7 +3,7 @@
 		"mimetype": "video/mp4"
 	},
 	"vtt": {
-		"mimetype": "text/vtt"
+		"mimetype": ".vtt"
 	},
 	"pdf": {
 		"mimetype": "application/pdf"
@@ -12,7 +12,7 @@
 		"mimetype": "application/epub+zip"
 	},
 	"mp3": {
-		"mimetype": "audio/mpeg"
+		"mimetype": ".mp3"
 	},
 	"jpg": {
 		"mimetype": "image/jpeg"
@@ -39,6 +39,6 @@
 		"mimetype": "application/perseus+zip"
 	},
 	"zip": {
-		"mimetype": "application/zip"
+		"mimetype": ".zip"
 	}
 }


### PR DESCRIPTION
Revert mimetype changes done in:
https://github.com/learningequality/le-utils/commit/b7e9748d9ba9a2518904821c746ddded01f4aa19#diff-675957a693bce24061dd680105e58225R59

Fixes Studio issue where HTML5App preview is broken.

TODO: revisit mimetypes after move-away-from-Dropzone task started:
https://www.notion.so/learningequality/Move-away-from-Dropzone-for-upload-management-6c3ae1a42a494a2ea3da3bfa4cb2af46