### PR TITLE
rm old Tagalog string in Baybayin script--

### DIFF
--- a/le_utils/resources/languagelookup.json
+++ b/le_utils/resources/languagelookup.json
@@ -690,7 +690,7 @@
   },
   "tl":{
     "name":"Tagalog",
-    "native_name":"Wikang Tagalog, ᜏᜒᜃᜅ᜔ ᜆᜄᜎᜓᜄ᜔"
+    "native_name":"Wikang Tagalog"
   },
   "tn":{
     "name":"Tswana",


### PR DESCRIPTION
Browsers are missing fonts so appears broken, not used 

fixes https://github.com/learningequality/le-utils/issues/56