### PR TITLE
Fixed order of document thumbnail

### DIFF
--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -114,7 +114,7 @@
 		"thumbnail": true,
 		"subtitle": false,
 		"display": true,
-		"order": 2,
+		"order": 3,
 		"kind": "document",
 		"allowed_formats": ["png", "jpg", "jpeg"],
 		"convertible_formats": []

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 setup(
     name="le-utils",
     packages = find_packages(),
-    version="0.1.17",
+    version="0.1.18",
     description="LE Utils and constants shared across Kolibri, Ricecooker, and the Kolibri Studio.",
     long_description=long_description,
     install_requires=requirements,


### PR DESCRIPTION
It looks like the document thumbnail order wasn't updated when we added epubs. As a result, the presets are getting displayed in the wrong order: https://github.com/learningequality/studio/issues/1328