### PR TITLE
Add other caption formats supported by pycaption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@ Release History
 ===============
 
 
+0.1.19 Jun 10, 2019
+-------------------
+  - Added additional formats for other caption file types that are convertible by `pycaption`:
+    - DFXP
+    - SAMI
+    - SCC
+    - TTML
+
+
+0.1.18 May 14, 2019
+-------------------
+  - Fixed `document_thumbnail.order` so previews default to the document instead of the thumbnail
+
+
 0.1.17 Apr 24, 2019
 -------------------
   - Added necessary constants for Slideshows:

--- a/le_utils/constants/file_formats.py
+++ b/le_utils/constants/file_formats.py
@@ -24,6 +24,10 @@ VTT = "vtt"
 VTT_MIMETYPE = ".vtt"
 # constants for formats convertible to VTT
 SRT = "srt"
+TTML = "ttml"
+SAMI = "sami"
+SCC = "scc"
+DFXP = "dfxp"
 
 # constants for Audio format
 MP3 = "mp3"

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -23,7 +23,7 @@
 		"allowed_formats": ["mp4"],
 		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv"]
 	},
-  "video_dependency": {
+	"video_dependency": {
 		"readable_name": "Video Dependency",
 		"multi_language": false,
 		"supplementary": true,
@@ -57,7 +57,7 @@
 		"order": 4,
 		"kind": "video",
 		"allowed_formats": ["vtt"],
-		"convertible_formats": ["srt"]
+		"convertible_formats": ["srt", "ttml", "sami", "scc", "dfxp"]
 	},
 	"audio": {
 		"readable_name": "Audio",
@@ -203,7 +203,7 @@
 		"allowed_formats": ["zip"],
 		"convertible_formats": []
 	},
-  "html5_dependency": {
+	"html5_dependency": {
 		"readable_name": "HTML5 Zip Dependency",
 		"multi_language": false,
 		"supplementary": true,

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requirements = [
 setup(
     name="le-utils",
     packages = find_packages(),
-    version="0.1.18",
+    version="0.1.19",
     description="LE Utils and constants shared across Kolibri, Ricecooker, and the Kolibri Studio.",
     long_description=long_description,
     install_requires=requirements,


### PR DESCRIPTION
I will be integrating `pycaption` into `pressurecooker` replacing the `srt2vtt` converter. As a bonus, we'll be able to convert a few other caption file formats, which this PR adds.