### PR TITLE
Add m4v to convertible_formats

### DIFF
--- a/le_utils/constants/file_formats.py
+++ b/le_utils/constants/file_formats.py
@@ -18,6 +18,8 @@ WMV = "wmv"
 WEBM = "webm"
 MKV = "mkv"
 FLV = "flv"
+OGV = "ogv"
+M4V = "m4v"
 
 # constants for Subtitle format
 VTT = "vtt"

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -9,7 +9,7 @@
 		"order": 1,
 		"kind": "video",
 		"allowed_formats": ["mp4"],
-		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv"]
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv", "m4v"]
 	},
 	"low_res_video": {
 		"readable_name": "Low Resolution",
@@ -21,7 +21,7 @@
 		"order": 2,
 		"kind": "video",
 		"allowed_formats": ["mp4"],
-		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv"]
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv", "m4v"]
 	},
 	"video_dependency": {
 		"readable_name": "Video Dependency",
@@ -33,7 +33,7 @@
 		"order": 3,
 		"kind": "video",
 		"allowed_formats": ["mp4"],
-		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv"]
+		"convertible_formats": ["avi", "mov", "mpg", "wmv", "webm", "mkv", "flv", "ogv", "m4v"]
 	},
 	"video_thumbnail": {
 		"readable_name": "Thumbnail",


### PR DESCRIPTION
Just adding 'm4v' extension to the convertible formats. 

Also noticed there is no constant for OGV = "ogv" so I added that
