### PR TITLE
Added zh-Hant language code and updated tests

### DIFF
--- a/le_utils/constants/languages.py
+++ b/le_utils/constants/languages.py
@@ -54,7 +54,7 @@ class Language(
 
 
 def _parse_out_iso_639_code(code):
-    code_regex = r'(?P<primary_code>\w{2,3})(-(?P<subcode>\w{2,3}))?'
+    code_regex = r'(?P<primary_code>\w{2,3})(-(?P<subcode>\w{2,4}))?'
 
     match = re.match(code_regex, code)
     if match:
@@ -205,13 +205,20 @@ def getlang_by_alpha2(code):
         language with the same `name` in the internal representaion
     Returns `None` if no matching language is found.
     """
+    # First try exact match to a language code in the internal representaion
+    exact_match = getlang(code)
+    if exact_match:
+        return exact_match
+
     # Handle special cases for language codes returned by YouTube API
     if code == 'iw':   # handle old Hebrew code 'iw' and return modern code 'he'
         return getlang('he')
-    elif 'zh-Hans' in code:
-        return getlang('zh-CN')   # use code `zh-CN` for all simplified Chinese
-    elif 'zh-Hant' in code or re.match('zh(.*)?-HK', code):
-        return getlang('zh-TW')   # use code `zh-TW` for all traditional Chinese
+    elif 'zh-Hans' in code:        # use code `zh-CN` for all simplified Chinese
+        return getlang('zh-CN')
+    elif re.match('zh(.*)?-TW', code):        # matches all Taiwan chinese codes
+        return getlang('zh-TW')
+    elif re.match('zh(.*)?-HK', code):        # use code `zh-Hant` for Hong Kong
+        return getlang('zh-Hant')
 
     # extract prefix only if specified with subcode: e.g. zh-Hans --> zh
     first_part = code.split('-')[0]

--- a/le_utils/resources/languagelookup.json
+++ b/le_utils/resources/languagelookup.json
@@ -132,10 +132,6 @@
     "name":"Chichewa; Chewa; Nyanja",
     "native_name":"chiCheŵa, chinyanja"
   },
-  "zh":{
-    "name":"Chinese",
-    "native_name":"中文 (Zhōngwén), 汉语, 漢語"
-  },
   "cv":{
     "name":"Chuvash",
     "native_name":"чӑваш чӗлхи"
@@ -826,13 +822,21 @@
     "name":"Urdu",
     "native_name":"Urdu"
   },
+  "zh":{
+    "name":"Chinese",
+    "native_name":"中文, 汉语, 漢語"
+  },
   "zh-CN":{
     "name":"Chinese, Simplified",
     "native_name":"中国大陆"
   },
-  "zh-TW":{
+  "zh-Hant":{
     "name":"Chinese, Traditional",
-    "native_name":"正體字/繁體字"
+    "native_name":"漢語 (繁體字)"
+  },
+  "zh-TW":{
+    "name":"Chinese, Taiwan",
+    "native_name":"漢語 (臺灣)"
   },
   "aka":{
     "name":"Akan",

--- a/tests/test_getlangs.py
+++ b/tests/test_getlangs.py
@@ -137,14 +137,19 @@ def test_unknown_alpha2_code():
 
 @pytest.fixture
 def simplified_chinese_codes():
-    return ['zh-Hans', 'zh-Hans-CN', 'zh-Hans-TW']
+    return ['zh-CN', 'zh-Hans', 'zh-Hans-CN']
 
 @pytest.fixture
 def traditional_chinese_codes():
-    return ['zh-Hant', 'zh-Hant-TW', 'zh-Hant-HK', 'zh-HK']
+    return ['zh-Hant', 'zh-Hant-HK', 'zh-HK']
+
+@pytest.fixture
+def taiwan_chinese_codes():
+    return ['zh-TW', 'zh-Hant-TW']
 
 
-def test_youtube_edgecases_alpha2_codes(simplified_chinese_codes, traditional_chinese_codes):
+def test_youtube_edgecases_alpha2_codes(simplified_chinese_codes,
+        traditional_chinese_codes, taiwan_chinese_codes):
     # check old language code for Hebrew works `iw`
     lang_obj = languages.getlang_by_alpha2('iw')
     assert lang_obj is not None, 'Hebrew not found'
@@ -160,13 +165,21 @@ def test_youtube_edgecases_alpha2_codes(simplified_chinese_codes, traditional_ch
         assert lang_obj.name == "Chinese, Simplified", 'Wrong name'
         assert lang_obj.native_name == "中国大陆", 'Wrong native_name'
 
-    # Check all Traditional Chinese codes are resolved correctly to zh-TW
+    # Check all Traditional Chinese codes are resolved correctly to zh-Hant
     for lang_code in traditional_chinese_codes:
         lang_obj = languages.getlang_by_alpha2(lang_code)
         assert lang_obj is not None, 'Traditional Chinese not found'
-        assert lang_obj.code == "zh-TW", 'Wrong internal repr. code'
+        assert lang_obj.code == "zh-Hant", 'Wrong internal repr. code'
         assert lang_obj.name == "Chinese, Traditional", 'Wrong name'
-        assert lang_obj.native_name == "正體字/繁體字", 'Wrong native_name'
+        assert lang_obj.native_name == "漢語 (繁體字)", 'Wrong native_name'
+
+    # Check all Taiwanese langauge codes are resolved correctly to zh-TW
+    for lang_code in taiwan_chinese_codes:
+        lang_obj = languages.getlang_by_alpha2(lang_code)
+        assert lang_obj is not None, 'Taiwan Chinese not found'
+        assert lang_obj.code == "zh-TW", 'Wrong internal repr. code'
+        assert lang_obj.name == "Chinese, Taiwan", 'Wrong name'
+        assert lang_obj.native_name == "漢語 (臺灣)", 'Wrong native_name'
 
 
 
@@ -209,24 +222,6 @@ def test_unknown_name():
 
 def test_language_names_with_modifier_in_bracket():
     # try to match based on language name (stuff before subcode in brackets)
-    lang_obj = languages.getlang_by_native_name('中文')
-    assert lang_obj is not None, 'Chinese 1 not found'
-    assert lang_obj.code == "zh", 'Wrong internal repr. code'
-    assert lang_obj.name == "Chinese", 'Wrong name'
-    assert lang_obj.native_name == "中文 (Zhōngwén), 汉语, 漢語", 'Wrong native_name'
-    #
-    lang_obj = languages.getlang_by_native_name('汉语')
-    assert lang_obj is not None, 'Chinese 2 not found'
-    assert lang_obj.code == "zh", 'Wrong internal repr. code'
-    assert lang_obj.name == "Chinese", 'Wrong name'
-    assert lang_obj.native_name == "中文 (Zhōngwén), 汉语, 漢語", 'Wrong native_name'
-    #
-    lang_obj = languages.getlang_by_native_name('漢語')
-    assert lang_obj is not None, 'Chinese 3 not found'
-    assert lang_obj.code == "zh", 'Wrong internal repr. code'
-    assert lang_obj.name == "Chinese", 'Wrong name'
-    assert lang_obj.native_name == "中文 (Zhōngwén), 汉语, 漢語", 'Wrong native_name'
-    #
     lang_obj = languages.getlang_by_native_name('日本語')
     assert lang_obj is not None, 'Japanese not found'
     assert lang_obj.code == "ja", 'Wrong internal repr. code'

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -37,5 +37,5 @@ def test_first_native_name():
     lang_obj = languages.getlang('zh')
     assert lang_obj is not None, 'Chinese not found'
     assert lang_obj.name == "Chinese", 'Wrong name'
-    assert lang_obj.native_name == "中文 (Zhōngwén), 汉语, 漢語", 'Wrong native_name'
-    assert lang_obj.first_native_name == "中文 (Zhōngwén)", 'Wrong first_native_name'
+    assert lang_obj.native_name == "中文, 汉语, 漢語", 'Wrong native_name'
+    assert lang_obj.first_native_name == "中文", 'Wrong first_native_name'


### PR DESCRIPTION
This PR introduces the new language code `zh-Hant` to be used for Traditional Chinese.

Previously we were using `zh-TW` to represent all traditional Chinese characters codes. The `zh-TW` code remains and is to be used only for language codes that match `zh-??-TW`.

The native names were updated to reflect the distinction, and corresponding tests were updated too.