### PR TITLE
Enable py36 and py37 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@
 language: python
 python:
   - 2.7
-  - 3.5
   - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -U setuptools && pip install -U tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py27, py34, py35, flake8
+envlist = py27, py34, py35, py36, py37, flake8
 
 [travis]
 python =
     2.7: py27
-    3.5: py35
     3.4: py34
+    3.5: py35
+    3.6: py35
+    3.7: py35
 
 
 [testenv]


### PR DESCRIPTION
to match all possibel py-version that migth be used by ricecooker 

(py34 not supported anymore but keeping it for now)