### PR TITLE
Python2 and Python3 compatible README.md read

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
+import io
 from setuptools import find_packages, setup
 
-long_description = open('README.md').read()
+long_description = io.open('README.md', encoding='utf-8').read()
 
 requirements = [
     "pycountry==17.5.14",


### PR DESCRIPTION
```
Collecting le-utils==0.1.24 (from -r requirements/base.txt (line 18))
  Downloading https://files.pythonhosted.org/packages/f7/5e/e499293c64010ca8e22d126c29b26c3255c41ecc74b7e903e5f1f2a34a54/le-utils-0.1.24.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-wjbv6qqa/le-utils/setup.py", line 3, in <module>
        long_description = open('README.md').read()
      File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 2845: ordinal not in range(128)
```