### PR TITLE
updated content_kinds.py

### DIFF
--- a/le_utils/constants/content_kinds.py
+++ b/le_utils/constants/content_kinds.py
@@ -31,6 +31,7 @@ choices = (
     (ZIM, "Zim"),
     (QUIZ, "Quiz"),
 )
+MAX_CHOICE_LENGTH = max([len(choice[0]) for choice in choices])
 
 """ File Format (extension) to Content Kind Mapping """
 MAPPING = {


### PR DESCRIPTION
**MAX_CHOICE_LENGTH** is good to use in case the choices of the content_kinds got changed . For example here in [kind field](https://github.com/learningequality/kolibri/blob/develop/kolibri/core/content/base_models.py#L128)  we can calculate the max_length in an automatic and convenient way