### PR TITLE
updated format_presets.py

### DIFF
--- a/le_utils/constants/format_presets.py
+++ b/le_utils/constants/format_presets.py
@@ -115,7 +115,7 @@ choices = (
     (SLIDESHOW_THUMBNAIL, SLIDESHOW_THUMBNAIL_READABLE),
     (SLIDESHOW_MANIFEST, SLIDESHOW_MANIFEST_READABLE),
 )
-
+MAX_CHOICE_LENGTH = max([len(choice[0]) for choice in choices])
 
 class Preset(
     namedtuple(


### PR DESCRIPTION
MAX_CHOICE_LENGTH is good to use in case the choices of the format_presets change. For example here in [preset_field](https://github.com/learningequality/kolibri/blob/develop/kolibri/core/content/base_models.py#L174)  we can calculate the max_length in an automatic and convenient way