### PR TITLE
Allow uploads of .h5p content file in Studio

### DIFF
--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -254,7 +254,7 @@
 	"h5p_thumbnail": {
 		"readable_name": "H5P Thumbnail",
 		"multi_language": false,
-		"supplementary": false,
+		"supplementary": true,
 		"thumbnail": true,
 		"subtitle": false,
 		"display": true,

--- a/le_utils/resources/presetlookup.json
+++ b/le_utils/resources/presetlookup.json
@@ -245,7 +245,7 @@
 		"supplementary": false,
 		"thumbnail": false,
 		"subtitle": false,
-		"display": false,
+		"display": true,
 		"order": 1,
 		"kind": "h5p",
 		"allowed_formats": ["h5p"],
@@ -254,7 +254,7 @@
 	"h5p_thumbnail": {
 		"readable_name": "H5P Thumbnail",
 		"multi_language": false,
-		"supplementary": true,
+		"supplementary": false,
 		"thumbnail": true,
 		"subtitle": false,
 		"display": true,


### PR DESCRIPTION
- This pr is first step towards completing the [parent pr](https://github.com/learningequality/studio/issues/4081).
- This Pr aims to allow studio to upload .h5p format files and their thumbnails. 
- This is simply done through updating the presetlookup json file.