### PR TITLE
Npm publish and pre commit

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+      - name: Install Python dependencies
+        run: |
+            python -m pip install --upgrade pip
+            pip install pre-commit
       - run: make release-npm
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_API_TOKEN}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,13 @@
 exclude: (\.git/|\.tox/|\.venv/|le_utils\.egg-info)
 repos:
+-   repo: local
+    hooks:
+    -   id: rebuild-from-specs
+        name: Regenerate files
+        description: Regenerates files when specs or version has changed
+        entry: make build
+        language: system
+        files: (spec/.*\.json|setup\.py)$
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:

--- a/scripts/generate_from_specs.py
+++ b/scripts/generate_from_specs.py
@@ -307,4 +307,7 @@ if __name__ == "__main__":
 
     output_files += set_package_json_version()
 
-    subprocess.call(["pre-commit", "run", "--files"] + output_files)
+    env = os.environ.copy()
+    env["SKIP"] = "rebuild-from-specs"
+
+    subprocess.call(["pre-commit", "run", "--files"] + output_files, env=env)

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     ],
     author="Learning Equality",
     author_email="info@learningequality.org",
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*,  <3.12",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*,  <3.13",
 )


### PR DESCRIPTION
Fixes NPM publishing by ensuring that pre-commit is installed.

Adds a pre-commit hook to regenerate specs to ensure that we are always committing rebuilt files when changing specs.

Excludes this new hook when running the generation script to avoid a potential recursive call.