### PR TITLE
Add level property to ancestors

### DIFF
--- a/js/EmbedTopicsRequest.js
+++ b/js/EmbedTopicsRequest.js
@@ -14,7 +14,14 @@ export const SCHEMA = {
       "type": "array",
       "description": "The ancestors of the topic, in order, from the parent to the root",
       "items": {
-        "$ref": "#/definitions/topic"
+        "$ref": "#/definitions/topic",
+        "properties": {
+          "level": {
+            "type": "integer",
+            "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
+          }
+        },
+        "required": ["level"]
       }
     },
     "language": {

--- a/js/EmbedTopicsRequest.js
+++ b/js/EmbedTopicsRequest.js
@@ -29,7 +29,7 @@ export const SCHEMA = {
     },
     "level": {
       "type": "integer",
-      "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
+      "description": "The level of the ancestor, where the root is 0 and the parent is the highest level"
     },
     "ancestor": {
       "type": "object",
@@ -61,7 +61,7 @@ export const SCHEMA = {
     },
     "ancestors": {
       "type": "array",
-      "description": "The ancestors of the topic, in order, from the parent to the root",
+      "description": "The ancestors of the topic. Please see 'level' in the ancestor schema for more information",
       "items": {
         "$ref": "#/definitions/ancestor"
       }

--- a/js/EmbedTopicsRequest.js
+++ b/js/EmbedTopicsRequest.js
@@ -10,24 +10,61 @@ export const SCHEMA = {
   "description": "Schema for embed topics requests received by RayServe",
   "additionalProperties": false,
   "definitions": {
-    "ancestors": {
-      "type": "array",
-      "description": "The ancestors of the topic, in order, from the parent to the root",
-      "items": {
-        "$ref": "#/definitions/topic",
-        "properties": {
-          "level": {
-            "type": "integer",
-            "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
-          }
-        },
-        "required": ["level"]
-      }
+     "id": {
+      "type": "string",
+      "description": "The ID of the topic content node on Studio"
+    },
+    "title": {
+      "type": "string",
+      "description": "The title of the topic"
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the topic"
     },
     "language": {
       "type": "string",
       "description": "Language code from https://github.com/learningequality/le-utils/blob/main/le_utils/resources/languagelookup.json",
       "pattern": "^[a-z]{2,3}(?:-[a-zA-Z]+)?$"
+    },
+    "level": {
+      "type": "integer",
+      "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
+    },
+    "ancestor": {
+      "type": "object",
+      "description": "An ancestor in the tree structure",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "language": {
+          "$ref": "#/definitions/language"
+        },
+        "level": {
+          "$ref": "#/definitions/level"
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "description",
+        "level"
+      ]
+    },
+    "ancestors": {
+      "type": "array",
+      "description": "The ancestors of the topic, in order, from the parent to the root",
+      "items": {
+        "$ref": "#/definitions/ancestor"
+      }
     },
     "topic": {
       "type": "object",
@@ -35,16 +72,13 @@ export const SCHEMA = {
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string",
-          "description": "The ID of the topic content node on Studio"
+          "$ref": "#/definitions/id"
         },
         "title": {
-          "type": "string",
-          "description": "The title of the topic"
+          "$ref": "#/definitions/title"
         },
         "description": {
-          "type": "string",
-          "description": "The description of the topic"
+          "$ref": "#/definitions/description"
         },
         "language": {
           "$ref": "#/definitions/language"

--- a/js/package.json
+++ b/js/package.json
@@ -27,5 +27,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.2.4"
+  "version": "0.2.5"
 }

--- a/le_utils/constants/embed_topics_request.py
+++ b/le_utils/constants/embed_topics_request.py
@@ -32,7 +32,7 @@ SCHEMA = {
         },
         "level": {
             "type": "integer",
-            "description": "The level of the ancestor, where the parent is 1 and the root is the highest level",
+            "description": "The level of the ancestor, where the root is 0 and the parent is the highest level",
         },
         "ancestor": {
             "type": "object",
@@ -49,7 +49,7 @@ SCHEMA = {
         },
         "ancestors": {
             "type": "array",
-            "description": "The ancestors of the topic, in order, from the parent to the root",
+            "description": "The ancestors of the topic. Please see 'level' in the ancestor schema for more information",
             "items": {"$ref": "#/definitions/ancestor"},
         },
         "topic": {

--- a/le_utils/constants/embed_topics_request.py
+++ b/le_utils/constants/embed_topics_request.py
@@ -16,39 +16,50 @@ SCHEMA = {
     "description": "Schema for embed topics requests received by RayServe",
     "additionalProperties": False,
     "definitions": {
-        "ancestors": {
-            "type": "array",
-            "description": "The ancestors of the topic, in order, from the parent to the root",
-            "items": {
-                "$ref": "#/definitions/topic",
-                "properties": {
-                    "level": {
-                        "type": "integer",
-                        "description": "The level of the ancestor, where the parent is 1 and the root is the highest level",
-                    }
-                },
-                "required": ["level"],
-            },
+        "id": {
+            "type": "string",
+            "description": "The ID of the topic content node on Studio",
+        },
+        "title": {"type": "string", "description": "The title of the topic"},
+        "description": {
+            "type": "string",
+            "description": "The description of the topic",
         },
         "language": {
             "type": "string",
             "description": "Language code from https://github.com/learningequality/le-utils/blob/main/le_utils/resources/languagelookup.json",
             "pattern": "^[a-z]{2,3}(?:-[a-zA-Z]+)?$",
         },
+        "level": {
+            "type": "integer",
+            "description": "The level of the ancestor, where the parent is 1 and the root is the highest level",
+        },
+        "ancestor": {
+            "type": "object",
+            "description": "An ancestor in the tree structure",
+            "additionalProperties": False,
+            "properties": {
+                "id": {"$ref": "#/definitions/id"},
+                "title": {"$ref": "#/definitions/title"},
+                "description": {"$ref": "#/definitions/description"},
+                "language": {"$ref": "#/definitions/language"},
+                "level": {"$ref": "#/definitions/level"},
+            },
+            "required": ["id", "title", "description", "level"],
+        },
+        "ancestors": {
+            "type": "array",
+            "description": "The ancestors of the topic, in order, from the parent to the root",
+            "items": {"$ref": "#/definitions/ancestor"},
+        },
         "topic": {
             "type": "object",
             "description": "A topic in the tree structure",
             "additionalProperties": False,
             "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "The ID of the topic content node on Studio",
-                },
-                "title": {"type": "string", "description": "The title of the topic"},
-                "description": {
-                    "type": "string",
-                    "description": "The description of the topic",
-                },
+                "id": {"$ref": "#/definitions/id"},
+                "title": {"$ref": "#/definitions/title"},
+                "description": {"$ref": "#/definitions/description"},
                 "language": {"$ref": "#/definitions/language"},
                 "ancestors": {"$ref": "#/definitions/ancestors"},
             },

--- a/le_utils/constants/embed_topics_request.py
+++ b/le_utils/constants/embed_topics_request.py
@@ -19,7 +19,16 @@ SCHEMA = {
         "ancestors": {
             "type": "array",
             "description": "The ancestors of the topic, in order, from the parent to the root",
-            "items": {"$ref": "#/definitions/topic"},
+            "items": {
+                "$ref": "#/definitions/topic",
+                "properties": {
+                    "level": {
+                        "type": "integer",
+                        "description": "The level of the ancestor, where the parent is 1 and the root is the highest level",
+                    }
+                },
+                "required": ["level"],
+            },
         },
         "language": {
             "type": "string",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ lang_utils_requirements = [
 setup(
     name="le-utils",
     packages=find_packages(),
-    version="0.2.4",
+    version="0.2.5",
     description="LE-Utils contains shared constants used in Kolibri, Ricecooker, and Kolibri Studio.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/spec/schema-embed_topics_request.json
+++ b/spec/schema-embed_topics_request.json
@@ -9,7 +9,14 @@
       "type": "array",
       "description": "The ancestors of the topic, in order, from the parent to the root",
       "items": {
-        "$ref": "#/definitions/topic"
+        "$ref": "#/definitions/topic",
+        "properties": {
+          "level": {
+            "type": "integer",
+            "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
+          }
+        },
+        "required": ["level"]
       }
     },
     "language": {

--- a/spec/schema-embed_topics_request.json
+++ b/spec/schema-embed_topics_request.json
@@ -24,7 +24,7 @@
     },
     "level": {
       "type": "integer",
-      "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
+      "description": "The level of the ancestor, where the root is 0 and the parent is the highest level"
     },
     "ancestor": {
       "type": "object",
@@ -56,7 +56,7 @@
     },
     "ancestors": {
       "type": "array",
-      "description": "The ancestors of the topic, in order, from the parent to the root",
+      "description": "The ancestors of the topic. Please see 'level' in the ancestor schema for more information",
       "items": {
         "$ref": "#/definitions/ancestor"
       }

--- a/spec/schema-embed_topics_request.json
+++ b/spec/schema-embed_topics_request.json
@@ -5,24 +5,61 @@
   "description": "Schema for embed topics requests received by RayServe",
   "additionalProperties": false,
   "definitions": {
-    "ancestors": {
-      "type": "array",
-      "description": "The ancestors of the topic, in order, from the parent to the root",
-      "items": {
-        "$ref": "#/definitions/topic",
-        "properties": {
-          "level": {
-            "type": "integer",
-            "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
-          }
-        },
-        "required": ["level"]
-      }
+     "id": {
+      "type": "string",
+      "description": "The ID of the topic content node on Studio"
+    },
+    "title": {
+      "type": "string",
+      "description": "The title of the topic"
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the topic"
     },
     "language": {
       "type": "string",
       "description": "Language code from https://github.com/learningequality/le-utils/blob/main/le_utils/resources/languagelookup.json",
       "pattern": "^[a-z]{2,3}(?:-[a-zA-Z]+)?$"
+    },
+    "level": {
+      "type": "integer",
+      "description": "The level of the ancestor, where the parent is 1 and the root is the highest level"
+    },
+    "ancestor": {
+      "type": "object",
+      "description": "An ancestor in the tree structure",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "title": {
+          "$ref": "#/definitions/title"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "language": {
+          "$ref": "#/definitions/language"
+        },
+        "level": {
+          "$ref": "#/definitions/level"
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "description",
+        "level"
+      ]
+    },
+    "ancestors": {
+      "type": "array",
+      "description": "The ancestors of the topic, in order, from the parent to the root",
+      "items": {
+        "$ref": "#/definitions/ancestor"
+      }
     },
     "topic": {
       "type": "object",
@@ -30,16 +67,13 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string",
-          "description": "The ID of the topic content node on Studio"
+          "$ref": "#/definitions/id"
         },
         "title": {
-          "type": "string",
-          "description": "The title of the topic"
+          "$ref": "#/definitions/title"
         },
         "description": {
-          "type": "string",
-          "description": "The description of the topic"
+          "$ref": "#/definitions/description"
         },
         "language": {
           "$ref": "#/definitions/language"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -272,7 +272,7 @@ def test_completion_criteria__reference__invalid():
 
 
 @pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
-def test_embed__topics__valid():
+def test_embed__topics__without__ancestors__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         validate_embed_topics_request(
             {
@@ -282,6 +282,37 @@ def test_embed__topics__valid():
                         "title": "Target topic",
                         "description": "Target description",
                         "language": "en",
+                    }
+                ],
+                "metadata": {
+                    "channel_id": "000",
+                    "channel_title": "Channel title",
+                    "some_additional_field": "some_random_value",
+                },
+            }
+        )
+
+
+@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+def test_embed__topics__with__ancestors__valid():
+    with _assert_not_raises(jsonschema.ValidationError):
+        validate_embed_topics_request(
+            {
+                "topics": [
+                    {
+                        "id": "456",
+                        "title": "Target topic",
+                        "description": "Target description",
+                        "language": "en",
+                        "ancestors": [
+                            {
+                                "id": "456",
+                                "title": "Parent topic",
+                                "description": "Parent description",
+                                "language": "en",
+                                "level": 1,
+                            }
+                        ],
                     }
                 ],
                 "metadata": {


### PR DESCRIPTION
## Overview
This pr adds a level property to the ancestors property in the embed topics schema. `level` is required when a topic has ancestors.