### PR TITLE
Update finalized specs check to remove deprecated output and runner

### DIFF
--- a/.github/workflows/finalized_specs.yml
+++ b/.github/workflows/finalized_specs.yml
@@ -21,12 +21,12 @@ jobs:
       - id: changes
         # Set outputs using the command.
         run: |
-          echo "::set-output name=modified::$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep spec/labels-v1.json$ | xargs)"
+          echo "modified=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep spec/labels-v1.json$ | xargs)" >> $GITHUB_OUTPUT
   unit_test:
     name: Error if finalized spec modified
     needs: change_check
     if: ${{ needs.change_check.outputs.modified }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: Fail if specs modified
       run: exit 1


### PR DESCRIPTION
Removes use of set-output in line with https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Updates runner to ubuntu-latest for maintainability