### PR TITLE
Add notify_team_new_comment github workflow

### DIFF
--- a/.github/workflows/notify_team_new_comment.yml
+++ b/.github/workflows/notify_team_new_comment.yml
@@ -1,0 +1,11 @@
+name: Send a slack notification when a contributor comments on issue
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  contributor_issue_comment:
+    uses: learningequality/.github/.github/workflows/notify_team_new_comment.yml@main
+    secrets:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
With https://github.com/learningequality/.github/pull/11
reusable action is added to .github repo. This PR makes use of it.

## References
Issue: https://github.com/learningequality/kolibri/issues/12567


## Reviewer guidance
Create Pull request similar to https://github.com/learningequality/test-actions/pull/53
Create issue and link it to PR
Change default repo branch to the branch you are changing in PR from (1.) due to https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment
Post comment in issue.
