### PR TITLE
 Drop use of deprecated and soon to be removed ubuntu-20.04 Github Actions runner

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -22,32 +22,70 @@ jobs:
   unit_test:
     name: Python unit tests
     needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11', '3.12', '3.13']
+        python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
     - name: Install tox
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: |
         python -m pip install --upgrade pip
         pip install tox
     - name: tox env cache
-      if: ${{ !startsWith(runner.os, 'windows') }}
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' && !startsWith(runner.os, 'windows') }}
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
         key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
     - name: Test with tox
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      run: tox -e py${{ matrix.python-version }}
+
+  unit_test_eol_python:
+    name: Python unit tests for EOL Python versions
+    needs: pre_job
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    container:
+      image: python:${{ matrix.python-version }}-buster
+    steps:
+    - uses: actions/checkout@v4
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    - name: Cache pip
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+    - name: Install tox
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: tox env cache
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' && !startsWith(runner.os, 'windows') }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/.tox/py${{ matrix.python-version }}
+        key: ${{ runner.os }}-tox-py${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
+    - name: Test with tox
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
       run: tox -e py${{ matrix.python-version }}


### PR DESCRIPTION
## Summary
* Update skip checking to be within matrix to allow required checks to show as skipped.
* Separate out EOL Python version tests to run in docker to use ubuntu-latest runner.

## References
Fix for le-utils part of https://github.com/learningequality/kolibri-ecosystem/issues/41

## Reviewer guidance
Do all tests still pass?

Note, this changes the name of some required tests, so it will so some checks as pending when they are really not. When this has been merged, we should update the required checks for this repo.
