### PR TITLE
Change metadata key to avoid parsing errors.

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -27,5 +27,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.2.8"
+  "version": "0.2.9"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-description-file = README.md
+long_description = file: README.md
 
 [flake8]
 max-line-length = 160

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ lang_utils_requirements = [
 setup(
     name="le-utils",
     packages=find_packages(),
-    version="0.2.8",
+    version="0.2.9",
     description="LE-Utils contains shared constants used in Kolibri, Ricecooker, and Kolibri Studio.",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
* Changes seemingly invalid metadata key to `long_description` using the `file: ` modifier as per https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#specifying-values
* Bumps version for new release

## References
Errors in Python tests/builds in Kolibri on Python 3.12+ e.g. https://app.readthedocs.org/projects/kolibri-dev/builds/27618651/

## Reviewer guidance
Hopefully the tests passing should be sufficient here?
