### PR TITLE
Update embed schemas for newly required fields

### DIFF
--- a/js/EmbedContentRequest.js
+++ b/js/EmbedContentRequest.js
@@ -84,6 +84,10 @@ export const SCHEMA = {
           "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
           "description": "The UUID of the content resource"
         },
+        "channel_id": {
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The UUID of the channel that the content resource belongs to"
+        },
         "title": {
           "type": "string",
           "description": "The title of the content resource"
@@ -94,7 +98,7 @@ export const SCHEMA = {
         },
         "text": {
           "type": "string",
-          "description": "The cleaned up text extracted from the content resource (in markdown or plaintext format)"
+          "description": "Optional textual content to include in the embedding"
         },
         "language": {
           "$ref": "#/definitions/language"
@@ -113,9 +117,9 @@ export const SCHEMA = {
       },
       "required": [
         "id",
+        "channel_id",
         "title",
         "description",
-        "text",
         "content_id"
       ]
     }

--- a/js/EmbedTopicsRequest.js
+++ b/js/EmbedTopicsRequest.js
@@ -11,7 +11,7 @@ export const SCHEMA = {
   "additionalProperties": false,
   "definitions": {
      "id": {
-      "type": "string",
+       "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
       "description": "The ID of the topic content node on Studio"
     },
     "title": {
@@ -90,7 +90,8 @@ export const SCHEMA = {
       "required": [
         "id",
         "title",
-        "description"
+        "description",
+        "language"
       ]
     }
   },

--- a/js/EmbedTopicsRequest.js
+++ b/js/EmbedTopicsRequest.js
@@ -10,10 +10,6 @@ export const SCHEMA = {
   "description": "Schema for embed topics requests received by RayServe",
   "additionalProperties": false,
   "definitions": {
-     "id": {
-       "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
-      "description": "The ID of the topic content node on Studio"
-    },
     "title": {
       "type": "string",
       "description": "The title of the topic"
@@ -37,7 +33,8 @@ export const SCHEMA = {
       "additionalProperties": false,
       "properties": {
         "id": {
-          "$ref": "#/definitions/id"
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The ID of the topic content node on Studio"
         },
         "title": {
           "$ref": "#/definitions/title"
@@ -72,7 +69,12 @@ export const SCHEMA = {
       "additionalProperties": false,
       "properties": {
         "id": {
-          "$ref": "#/definitions/id"
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The ID of the topic content node on Studio"
+        },
+        "channel_id": {
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The UUID of the channel that the topic belongs to"
         },
         "title": {
           "$ref": "#/definitions/title"
@@ -89,6 +91,7 @@ export const SCHEMA = {
       },
       "required": [
         "id",
+        "channel_id",
         "title",
         "description",
         "language"

--- a/js/package.json
+++ b/js/package.json
@@ -27,5 +27,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.2.10"
+  "version": "0.2.11"
 }

--- a/le_utils/constants/embed_content_request.py
+++ b/le_utils/constants/embed_content_request.py
@@ -81,6 +81,10 @@ SCHEMA = {
                     "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
                     "description": "The UUID of the content resource",
                 },
+                "channel_id": {
+                    "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+                    "description": "The UUID of the channel that the content resource belongs to",
+                },
                 "title": {
                     "type": "string",
                     "description": "The title of the content resource",
@@ -91,7 +95,7 @@ SCHEMA = {
                 },
                 "text": {
                     "type": "string",
-                    "description": "The cleaned up text extracted from the content resource (in markdown or plaintext format)",
+                    "description": "Optional textual content to include in the embedding",
                 },
                 "language": {"$ref": "#/definitions/language"},
                 "files": {
@@ -104,7 +108,7 @@ SCHEMA = {
                     "description": "The UUID of the content resource(s)",
                 },
             },
-            "required": ["id", "title", "description", "text", "content_id"],
+            "required": ["id", "channel_id", "title", "description", "content_id"],
         },
     },
     "properties": {

--- a/le_utils/constants/embed_topics_request.py
+++ b/le_utils/constants/embed_topics_request.py
@@ -17,7 +17,7 @@ SCHEMA = {
     "additionalProperties": False,
     "definitions": {
         "id": {
-            "type": "string",
+            "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
             "description": "The ID of the topic content node on Studio",
         },
         "title": {"type": "string", "description": "The title of the topic"},
@@ -63,7 +63,7 @@ SCHEMA = {
                 "language": {"$ref": "#/definitions/language"},
                 "ancestors": {"$ref": "#/definitions/ancestors"},
             },
-            "required": ["id", "title", "description"],
+            "required": ["id", "title", "description", "language"],
         },
     },
     "properties": {

--- a/le_utils/constants/embed_topics_request.py
+++ b/le_utils/constants/embed_topics_request.py
@@ -16,10 +16,6 @@ SCHEMA = {
     "description": "Schema for embed topics requests received by RayServe",
     "additionalProperties": False,
     "definitions": {
-        "id": {
-            "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
-            "description": "The ID of the topic content node on Studio",
-        },
         "title": {"type": "string", "description": "The title of the topic"},
         "description": {
             "type": "string",
@@ -39,7 +35,10 @@ SCHEMA = {
             "description": "An ancestor in the tree structure",
             "additionalProperties": False,
             "properties": {
-                "id": {"$ref": "#/definitions/id"},
+                "id": {
+                    "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+                    "description": "The ID of the topic content node on Studio",
+                },
                 "title": {"$ref": "#/definitions/title"},
                 "description": {"$ref": "#/definitions/description"},
                 "language": {"$ref": "#/definitions/language"},
@@ -57,13 +56,20 @@ SCHEMA = {
             "description": "A topic in the tree structure",
             "additionalProperties": False,
             "properties": {
-                "id": {"$ref": "#/definitions/id"},
+                "id": {
+                    "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+                    "description": "The ID of the topic content node on Studio",
+                },
+                "channel_id": {
+                    "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+                    "description": "The UUID of the channel that the topic belongs to",
+                },
                 "title": {"$ref": "#/definitions/title"},
                 "description": {"$ref": "#/definitions/description"},
                 "language": {"$ref": "#/definitions/language"},
                 "ancestors": {"$ref": "#/definitions/ancestors"},
             },
-            "required": ["id", "title", "description", "language"],
+            "required": ["id", "channel_id", "title", "description", "language"],
         },
     },
     "properties": {

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = io.open("README.md", encoding="utf-8").read()
 setup(
     name="le-utils",
     packages=find_packages(),
-    version="0.2.10",
+    version="0.2.11",
     description="LE-Utils contains shared constants used in Kolibri, Ricecooker, and Kolibri Studio.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/spec/schema-embed_content_request.json
+++ b/spec/schema-embed_content_request.json
@@ -79,6 +79,10 @@
           "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
           "description": "The UUID of the content resource"
         },
+        "channel_id": {
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The UUID of the channel that the content resource belongs to"
+        },
         "title": {
           "type": "string",
           "description": "The title of the content resource"
@@ -89,7 +93,7 @@
         },
         "text": {
           "type": "string",
-          "description": "The cleaned up text extracted from the content resource (in markdown or plaintext format)"
+          "description": "Optional textual content to include in the embedding"
         },
         "language": {
           "$ref": "#/definitions/language"
@@ -108,9 +112,9 @@
       },
       "required": [
         "id",
+        "channel_id",
         "title",
         "description",
-        "text",
         "content_id"
       ]
     }

--- a/spec/schema-embed_topics_request.json
+++ b/spec/schema-embed_topics_request.json
@@ -6,7 +6,7 @@
   "additionalProperties": false,
   "definitions": {
      "id": {
-      "type": "string",
+       "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
       "description": "The ID of the topic content node on Studio"
     },
     "title": {
@@ -85,7 +85,8 @@
       "required": [
         "id",
         "title",
-        "description"
+        "description",
+        "language"
       ]
     }
   },

--- a/spec/schema-embed_topics_request.json
+++ b/spec/schema-embed_topics_request.json
@@ -5,10 +5,6 @@
   "description": "Schema for embed topics requests received by RayServe",
   "additionalProperties": false,
   "definitions": {
-     "id": {
-       "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
-      "description": "The ID of the topic content node on Studio"
-    },
     "title": {
       "type": "string",
       "description": "The title of the topic"
@@ -32,7 +28,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "$ref": "#/definitions/id"
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The ID of the topic content node on Studio"
         },
         "title": {
           "$ref": "#/definitions/title"
@@ -67,7 +64,12 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "$ref": "#/definitions/id"
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The ID of the topic content node on Studio"
+        },
+        "channel_id": {
+          "$ref": "/schemas/common_embed_definitions#/definitions/uuid",
+          "description": "The UUID of the channel that the topic belongs to"
         },
         "title": {
           "$ref": "#/definitions/title"
@@ -84,6 +86,7 @@
       },
       "required": [
         "id",
+        "channel_id",
         "title",
         "description",
         "language"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -287,6 +287,7 @@ def test_embed__topics__without_ancestors__valid():
                 "topics": [
                     {
                         "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Target topic",
                         "description": "Target description",
                         "language": "en",
@@ -308,6 +309,7 @@ def test_embed__topics__with_ancestors__valid():
                 "topics": [
                     {
                         "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Target topic",
                         "description": "Target description",
                         "language": "en",
@@ -316,7 +318,6 @@ def test_embed__topics__with_ancestors__valid():
                                 "id": str(uuid.uuid4()),
                                 "title": "Parent topic",
                                 "description": "Parent description",
-                                "language": "en",
                                 "level": 1,
                             }
                         ],
@@ -338,6 +339,7 @@ def test_embed__topics__invalid_id():
                 "topics": [
                     {
                         "id": "123",
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Target topic",
                         "description": "Target description",
                         "language": "en",
@@ -359,8 +361,52 @@ def test_embed__topics__missing_language():
                 "topics": [
                     {
                         "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Target topic",
                         "description": "Target description",
+                    }
+                ],
+                "metadata": {
+                    "channel_title": "Channel title",
+                    "some_additional_field": "some_random_value",
+                },
+            }
+        )
+
+
+@skip_if_jsonschema_unavailable
+def test_embed__topics__invalid_channel_id():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_embed_topics_request(
+            {
+                "topics": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "channel_id": "123",
+                        "title": "Target topic",
+                        "description": "Target description",
+                        "language": "en",
+                    }
+                ],
+                "metadata": {
+                    "channel_title": "Channel title",
+                    "some_additional_field": "some_random_value",
+                },
+            }
+        )
+
+
+@skip_if_jsonschema_unavailable
+def test_embed__topics__missing_channel_id():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_embed_topics_request(
+            {
+                "topics": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "title": "Target topic",
+                        "description": "Target description",
+                        "language": "en",
                     }
                 ],
                 "metadata": {

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import contextlib
+import uuid
 
 import pytest
 
@@ -19,6 +20,13 @@ try:
     import jsonschema
 except ImportError:
     jsonschema = None
+
+
+# create a common decorator to skip tests if jsonschema is not available
+skip_if_jsonschema_unavailable = pytest.mark.skipif(
+    jsonschema is None, reason="jsonschema package is unavailable"
+)
+
 
 resolver = None
 if jsonschema is not None:
@@ -52,7 +60,7 @@ def _assert_not_raises(not_expected):
             raise e
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__time_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -66,7 +74,7 @@ def test_completion_criteria__time_model__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__time_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -85,7 +93,7 @@ def test_completion_criteria__time_model__invalid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__approx_time_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -99,7 +107,7 @@ def test_completion_criteria__approx_time_model__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__approx_time_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -118,7 +126,7 @@ def test_completion_criteria__approx_time_model__invalid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -132,7 +140,7 @@ def test_completion_criteria__pages_model__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__percentage__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -149,7 +157,7 @@ def test_completion_criteria__pages_model__percentage__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -168,7 +176,7 @@ def test_completion_criteria__pages_model__invalid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__percentage__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -187,7 +195,7 @@ def test_completion_criteria__pages_model__percentage__invalid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__mastery_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -205,7 +213,7 @@ def test_completion_criteria__mastery_model__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__mastery_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -240,7 +248,7 @@ def test_completion_criteria__mastery_model__invalid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__reference__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria({"model": "reference", "learner_managed": False})
@@ -251,7 +259,7 @@ def test_completion_criteria__reference__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
 def test_completion_criteria__reference__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -271,21 +279,20 @@ def test_completion_criteria__reference__invalid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
-def test_embed__topics__without__ancestors__valid():
+@skip_if_jsonschema_unavailable
+def test_embed__topics__without_ancestors__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         validate_embed_topics_request(
             {
                 "topics": [
                     {
-                        "id": "456",
+                        "id": str(uuid.uuid4()),
                         "title": "Target topic",
                         "description": "Target description",
                         "language": "en",
                     }
                 ],
                 "metadata": {
-                    "channel_id": "000",
                     "channel_title": "Channel title",
                     "some_additional_field": "some_random_value",
                 },
@@ -293,20 +300,20 @@ def test_embed__topics__without__ancestors__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
-def test_embed__topics__with__ancestors__valid():
+@skip_if_jsonschema_unavailable
+def test_embed__topics__with_ancestors__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         validate_embed_topics_request(
             {
                 "topics": [
                     {
-                        "id": "456",
+                        "id": str(uuid.uuid4()),
                         "title": "Target topic",
                         "description": "Target description",
                         "language": "en",
                         "ancestors": [
                             {
-                                "id": "456",
+                                "id": str(uuid.uuid4()),
                                 "title": "Parent topic",
                                 "description": "Parent description",
                                 "language": "en",
@@ -316,7 +323,6 @@ def test_embed__topics__with__ancestors__valid():
                     }
                 ],
                 "metadata": {
-                    "channel_id": "000",
                     "channel_title": "Channel title",
                     "some_additional_field": "some_random_value",
                 },
@@ -324,23 +330,64 @@ def test_embed__topics__with__ancestors__valid():
         )
 
 
-@pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
+@skip_if_jsonschema_unavailable
+def test_embed__topics__invalid_id():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_embed_topics_request(
+            {
+                "topics": [
+                    {
+                        "id": "123",
+                        "title": "Target topic",
+                        "description": "Target description",
+                        "language": "en",
+                    }
+                ],
+                "metadata": {
+                    "channel_title": "Channel title",
+                    "some_additional_field": "some_random_value",
+                },
+            }
+        )
+
+
+@skip_if_jsonschema_unavailable
+def test_embed__topics__missing_language():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_embed_topics_request(
+            {
+                "topics": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "title": "Target topic",
+                        "description": "Target description",
+                    }
+                ],
+                "metadata": {
+                    "channel_title": "Channel title",
+                    "some_additional_field": "some_random_value",
+                },
+            }
+        )
+
+
+@skip_if_jsonschema_unavailable
 def test_embed__content__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         validate_embed_content_request(
             {
                 "resources": [
                     {
-                        "id": "123e4567-e89b-42d3-a456-556642440000",
+                        "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Resource title",
                         "description": "Resource description",
                         "text": "Resource text",
                         "language": "en",
-                        "content_id": "123e4567-e89b-42d3-a456-556642440000",
+                        "content_id": str(uuid.uuid4()),
                     },
                 ],
                 "metadata": {
-                    "channel_id": "000",
                     "channel_title": "Channel title",
                     "some_additional_field": "some_random_value",
                 },
@@ -348,18 +395,20 @@ def test_embed__content__valid():
         )
 
 
+@skip_if_jsonschema_unavailable
 def test_embed__content__valid_with_files():
     with _assert_not_raises(jsonschema.ValidationError):
         validate_embed_content_request(
             {
                 "resources": [
                     {
-                        "id": "123e4567-e89b-42d3-a456-556642440000",
+                        "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Resource title",
                         "description": "Resource description",
                         "text": "Resource text",
                         "language": "en",
-                        "content_id": "123e4567-e89b-42d3-a456-556642440000",
+                        "content_id": str(uuid.uuid4()),
                         "files": [
                             {
                                 "url": "http://localhost:8000/media/1234.jpg",
@@ -387,6 +436,7 @@ def test_embed__content__valid_with_files():
         )
 
 
+@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_id():
     with pytest.raises(jsonschema.ValidationError):
         validate_embed_content_request(
@@ -394,15 +444,15 @@ def test_embed__content__invalid_id():
                 "resources": [
                     {
                         "id": "123",
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Resource title",
                         "description": "Resource description",
                         "text": "Resource text",
                         "language": "en",
-                        "content_id": "123e4567-e89b-42d3-a456-556642440000",
+                        "content_id": str(uuid.uuid4()),
                     },
                 ],
                 "metadata": {
-                    "channel_id": "000",
                     "channel_title": "Channel title",
                     "some_additional_field": "some_random_value",
                 },
@@ -410,13 +460,39 @@ def test_embed__content__invalid_id():
         )
 
 
+@skip_if_jsonschema_unavailable
+def test_embed__content__invalid_channel_id():
+    with pytest.raises(jsonschema.ValidationError):
+        validate_embed_content_request(
+            {
+                "resources": [
+                    {
+                        "id": str(uuid.uuid4()),
+                        "channel_id": "123",
+                        "title": "Resource title",
+                        "description": "Resource description",
+                        "text": "Resource text",
+                        "language": "en",
+                        "content_id": str(uuid.uuid4()),
+                    },
+                ],
+                "metadata": {
+                    "channel_title": "Channel title",
+                    "some_additional_field": "some_random_value",
+                },
+            }
+        )
+
+
+@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_content_id():
     with pytest.raises(jsonschema.ValidationError):
         validate_embed_content_request(
             {
                 "resources": [
                     {
-                        "id": "123e4567-e89b-42d3-a456-556642440000",
+                        "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Resource title",
                         "description": "Resource description",
                         "text": "Resource text",
@@ -425,7 +501,6 @@ def test_embed__content__invalid_content_id():
                     },
                 ],
                 "metadata": {
-                    "channel_id": "000",
                     "channel_title": "Channel title",
                     "some_additional_field": "some_random_value",
                 },
@@ -433,18 +508,20 @@ def test_embed__content__invalid_content_id():
         )
 
 
+@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_url_files():
     with pytest.raises(jsonschema.ValidationError):
         validate_embed_content_request(
             {
                 "resources": [
                     {
-                        "id": "123e4567-e89b-42d3-a456-556642440000",
+                        "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Resource title",
                         "description": "Resource description",
                         "text": "Resource text",
                         "language": "en",
-                        "content_id": "123e4567-e89b-42d3-a456-556642440000",
+                        "content_id": str(uuid.uuid4()),
                         "files": [
                             {
                                 "url": "https://example.com/media/1234.jpg",
@@ -454,7 +531,6 @@ def test_embed__content__invalid_url_files():
                     },
                 ],
                 "metadata": {
-                    "channel_id": "000",
                     "channel_title": "Channel title",
                     "some_additional_field": "some_random_value",
                 },
@@ -462,18 +538,20 @@ def test_embed__content__invalid_url_files():
         )
 
 
+@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_preset_files():
     with pytest.raises(jsonschema.ValidationError):
         validate_embed_content_request(
             {
                 "resources": [
                     {
-                        "id": "123e4567-e89b-42d3-a456-556642440000",
+                        "id": str(uuid.uuid4()),
+                        "channel_id": str(uuid.uuid4()),
                         "title": "Resource title",
                         "description": "Resource description",
                         "text": "Resource text",
                         "language": "en",
-                        "content_id": "123e4567-e89b-42d3-a456-556642440000",
+                        "content_id": str(uuid.uuid4()),
                         "files": [
                             {
                                 "url": "http://localhost:8080/media/1234.jpg",
@@ -483,7 +561,6 @@ def test_embed__content__invalid_preset_files():
                     },
                 ],
                 "metadata": {
-                    "channel_id": "000",
                     "channel_title": "Channel title",
                     "some_additional_field": "some_random_value",
                 },


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Adds mandatory `channel_id` to the schemas, particularly important for the content embedding requests
- Ensured all IDs are now enforced as UUIDs (with dashes), which will require updates in Studio and CA API to add / remove dashes
- Enforces `language` is passed in topic embedding requests, and removes duplicitous ancestor definition to prioritize the one definition on the target topic

## References
<!--
 * references to related issues and PRs
 * links to mockups or specs for new features
 * links to the diffs for any dependency updates, e.g. in iceqube or the perseus plugin
-->
closes https://github.com/learningequality/le-utils/issues/158

## Reviewer guidance
<!--
 * how can a reviewer test these changes?
 * are there any risky areas that deserve extra testing
-->
Test updates make sense?
