### PR TITLE
Cleanup conditional test behaviour for jsonschema as Python 3.4 no longer supported/tested.

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -6,27 +6,16 @@ import json
 import pkgutil
 import uuid
 
+import jsonschema
 import pytest
 
 from le_utils.constants import completion_criteria, embed_content_request, embed_topics_request, learning_objectives, mastery_criteria
 
-try:
-    # the jsonschema package for python 3.4 is too old, so if not present, we'll just skip
-    import jsonschema
-except ImportError:
-    jsonschema = None
 
-
-# create a common decorator to skip tests if jsonschema is not available
-skip_if_jsonschema_unavailable = pytest.mark.skipif(jsonschema is None, reason="jsonschema package is unavailable")
-
-
-resolver = None
-if jsonschema is not None:
-    # this is an example of how to include the mastery criteria schema, which is referenced by the
-    # completion criteria schema, in the schema resolver so that it validates
-    resolver = jsonschema.RefResolver.from_schema(mastery_criteria.SCHEMA)
-    resolver.store.update(jsonschema.RefResolver.from_schema(completion_criteria.SCHEMA).store)
+# this is an example of how to include the mastery criteria schema, which is referenced by the
+# completion criteria schema, in the schema resolver so that it validates
+resolver = jsonschema.RefResolver.from_schema(mastery_criteria.SCHEMA)
+resolver.store.update(jsonschema.RefResolver.from_schema(completion_criteria.SCHEMA).store)
 
 
 def _validate_embed_content_request(data):
@@ -73,7 +62,6 @@ def _assert_not_raises(not_expected):
             raise e
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__time_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria({"model": "time", "threshold": 2, "learner_managed": False})
@@ -85,7 +73,6 @@ def test_completion_criteria__time_model__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__time_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -104,7 +91,6 @@ def test_completion_criteria__time_model__invalid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__approx_time_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria({"model": "approx_time", "threshold": 2, "learner_managed": False})
@@ -116,7 +102,6 @@ def test_completion_criteria__approx_time_model__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__approx_time_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -135,7 +120,6 @@ def test_completion_criteria__approx_time_model__invalid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria({"model": "pages", "threshold": 2, "learner_managed": False})
@@ -147,7 +131,6 @@ def test_completion_criteria__pages_model__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__percentage__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -164,7 +147,6 @@ def test_completion_criteria__pages_model__percentage__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -183,7 +165,6 @@ def test_completion_criteria__pages_model__invalid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__pages_model__percentage__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -202,7 +183,6 @@ def test_completion_criteria__pages_model__percentage__invalid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__mastery_model__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -236,7 +216,6 @@ def test_completion_criteria__mastery_model__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__mastery_model__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -302,7 +281,6 @@ def test_completion_criteria__mastery_model__invalid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__reference__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_completion_criteria({"model": "reference", "learner_managed": False})
@@ -313,7 +291,6 @@ def test_completion_criteria__reference__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_completion_criteria__reference__invalid():
     with pytest.raises(jsonschema.ValidationError):
         _validate_completion_criteria(
@@ -333,7 +310,6 @@ def test_completion_criteria__reference__invalid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__topics__without_ancestors__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_embed_topics_request(
@@ -355,7 +331,6 @@ def test_embed__topics__without_ancestors__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__topics__with_ancestors__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_embed_topics_request(
@@ -385,7 +360,6 @@ def test_embed__topics__with_ancestors__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__topics__invalid_id():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_topics_request(
@@ -407,7 +381,6 @@ def test_embed__topics__invalid_id():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__topics__missing_language():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_topics_request(
@@ -428,7 +401,6 @@ def test_embed__topics__missing_language():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__topics__invalid_channel_id():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_topics_request(
@@ -450,7 +422,6 @@ def test_embed__topics__invalid_channel_id():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__topics__missing_channel_id():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_topics_request(
@@ -471,7 +442,6 @@ def test_embed__topics__missing_channel_id():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__topics__all_languagelookup_codes_valid():
     """Every language code in languagelookup.json must be accepted by the topics schema.
 
@@ -496,7 +466,6 @@ def test_embed__topics__all_languagelookup_codes_valid():
             )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -521,7 +490,6 @@ def test_embed__content__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__valid_with_files():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -563,7 +531,6 @@ def test_embed__content__valid_with_files():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_id():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -587,7 +554,6 @@ def test_embed__content__invalid_id():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_channel_id():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -611,7 +577,6 @@ def test_embed__content__invalid_channel_id():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_content_id():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -635,7 +600,6 @@ def test_embed__content__invalid_content_id():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_channel_version():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -660,7 +624,6 @@ def test_embed__content__invalid_channel_version():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_url_files():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -690,7 +653,6 @@ def test_embed__content__invalid_url_files():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__invalid_preset_files():
     with pytest.raises(jsonschema.ValidationError):
         _validate_embed_content_request(
@@ -720,7 +682,6 @@ def test_embed__content__invalid_preset_files():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_embed__content__all_languagelookup_codes_valid():
     """Every language code in languagelookup.json must be accepted by the content schema.
 
@@ -756,7 +717,6 @@ def _validate_learning_objectives(data):
     jsonschema.validate(instance=data, schema=learning_objectives.SCHEMA)
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__valid():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_learning_objectives(
@@ -787,7 +747,6 @@ def test_learning_objectives__valid():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__valid_uuid_v5():
     with _assert_not_raises(jsonschema.ValidationError):
         _validate_learning_objectives(
@@ -818,7 +777,6 @@ def test_learning_objectives__valid_uuid_v5():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_lo_structure():
     with pytest.raises(jsonschema.ValidationError):
         _validate_learning_objectives(
@@ -832,7 +790,6 @@ def test_learning_objectives__invalid_lo_structure():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_assessment_mapping():
     with pytest.raises(jsonschema.ValidationError):
         _validate_learning_objectives(
@@ -846,7 +803,6 @@ def test_learning_objectives__invalid_assessment_mapping():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_lesson_mapping():
     with pytest.raises(jsonschema.ValidationError):
         _validate_learning_objectives(
@@ -860,7 +816,6 @@ def test_learning_objectives__invalid_lesson_mapping():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__missing_required_fields():
     # Missing learning_objectives
     with pytest.raises(jsonschema.ValidationError):
@@ -890,7 +845,6 @@ def test_learning_objectives__missing_required_fields():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__empty_structures():
     # Empty learning_objectives
     with pytest.raises(jsonschema.ValidationError):
@@ -923,7 +877,6 @@ def test_learning_objectives__empty_structures():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_uuid_format_in_learning_objectives():
     # Invalid UUID format for learning objective ID
     with pytest.raises(jsonschema.ValidationError):
@@ -936,7 +889,6 @@ def test_learning_objectives__invalid_uuid_format_in_learning_objectives():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_uuid_format_in_references():
     # Invalid UUID format in assessment and lesson objective references
     with pytest.raises(jsonschema.ValidationError):
@@ -949,7 +901,6 @@ def test_learning_objectives__invalid_uuid_format_in_references():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_question_id_pattern():
     # Invalid question ID pattern (not a valid UUID v4)
     with pytest.raises(jsonschema.ValidationError):
@@ -962,7 +913,6 @@ def test_learning_objectives__invalid_question_id_pattern():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_lesson_id_pattern():
     # Invalid lesson ID pattern (has extra characters)
     with pytest.raises(jsonschema.ValidationError):
@@ -975,7 +925,6 @@ def test_learning_objectives__invalid_lesson_id_pattern():
         )
 
 
-@skip_if_jsonschema_unavailable
 def test_learning_objectives__invalid_text_patterns():
     # Empty text after trimming whitespace
     with pytest.raises(jsonschema.ValidationError):


### PR DESCRIPTION
## Summary
When we dropped support for Python 2.7/3.4 in le-utils we forgot to cleanup the conditional jsonschema imports in the schema tests.
This does that!

## Reviewer guidance
Do tests still pass on all Python versions?