### PR TITLE
Switch ruff isort to one-import-per-line style

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Migrate to ruff formatter (replaces black)
 fdf3066e3346c925faaf8fdc3746698588d77dad
+
+# Reformatted imports after switching ruff isort to one-per-line
+1e54be6ea46787429cd7a060bfa17187dbb6510a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,7 @@ max-complexity = 10
 
 [tool.ruff.lint.isort]
 known-first-party = ["le_utils"]
-combine-as-imports = true
+# Match the prior reorder-python-imports style: one import per line,
+# sorted case-insensitively rather than grouped by type.
+force-single-line = true
+order-by-type = false

--- a/scripts/add_language.py
+++ b/scripts/add_language.py
@@ -4,7 +4,9 @@ import json
 import logging
 import os
 import sys
-from typing import Any, Dict, Optional
+from typing import Any
+from typing import Dict
+from typing import Optional
 
 try:
     import langcodes

--- a/scripts/generate_from_specs.py
+++ b/scripts/generate_from_specs.py
@@ -15,7 +15,8 @@ from collections import OrderedDict
 from glob import glob
 from hashlib import md5
 from importlib.metadata import version as get_version
-from uuid import UUID, uuid3
+from uuid import UUID
+from uuid import uuid3
 
 try:
     FileNotFoundError

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -8,7 +8,11 @@ import uuid
 
 import pytest
 
-from le_utils.constants import completion_criteria, embed_content_request, embed_topics_request, learning_objectives, mastery_criteria
+from le_utils.constants import completion_criteria
+from le_utils.constants import embed_content_request
+from le_utils.constants import embed_topics_request
+from le_utils.constants import learning_objectives
+from le_utils.constants import mastery_criteria
 
 try:
     # the jsonschema package for python 3.4 is too old, so if not present, we'll just skip


### PR DESCRIPTION
## Summary

le-utils already enabled ruff's `I` import rules during its uv migration, but with `combine-as-imports` and default type-grouping — combined imports, CapWords-first. This switches isort to `force-single-line` and `order-by-type = false` so it matches the prior `reorder_python_imports` one-per-line, case-insensitive style used across the other LE repos.

Three commits: the config change, a mechanical one-time reformat (3 files, `ruff check --fix`), and a `.git-blame-ignore-revs` entry for the reformat.

## References

None — no tracking issue. Part of a cross-repo pass aligning import-ordering style after the uv migrations.

## Reviewer guidance

The reformat commit is purely mechanical — review the config commit for intent. The reformat is excluded from `git blame` via `.git-blame-ignore-revs`. Verify with `ruff check --select I .` (clean on the branch).

Each reformat diff was scanned for semantic import-order changes; none were found in this repo.

## AI usage

Used Claude Code to identify the style divergence from the other repos, derive the ruff isort config that reproduces the old `reorder_python_imports` behaviour, and apply it. The reformat diff was reviewed before committing.