### PR TITLE
Decouple js/package.json version from setuptools-scm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ release: dist
 	uv publish
 
 release-npm: clean build
+	uv run python scripts/set_npm_version.py
 	cd js && npm publish
 
 add-language:

--- a/js/package.json
+++ b/js/package.json
@@ -27,5 +27,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.2.18"
+  "version": "0.0.0"
 }

--- a/scripts/generate_from_specs.py
+++ b/scripts/generate_from_specs.py
@@ -14,7 +14,6 @@ import sys
 from collections import OrderedDict
 from glob import glob
 from hashlib import md5
-from importlib.metadata import version as get_version
 from uuid import UUID
 from uuid import uuid3
 
@@ -259,43 +258,6 @@ def write_constants_src_files(constants_outputs, schemas):
     return output_files
 
 
-def pep440_to_npm_semver(version):
-    """Convert a PEP 440 version to npm-compatible semver.
-
-    Extracts just the base version (X.Y.Z) to ensure the version is
-    stable across commits and valid npm semver. Dev/local suffixes from
-    setuptools-scm change with every commit, which would cause the
-    rebuild-from-specs pre-commit hook to perpetually modify this file.
-    On tagged releases, setuptools-scm returns the clean version directly.
-    """
-    match = re.match(r"(\d+\.\d+\.\d+)", version)
-    return match.group(1) if match else version
-
-
-def set_package_json_version():
-    python_version = get_version("le-utils")
-    npm_version = pep440_to_npm_semver(python_version)
-
-    package_json = os.path.join(js_output_dir, "package.json")
-
-    with open(package_json, "r") as f:
-        package = json.load(f)
-
-    package["version"] = npm_version
-
-    with open(package_json, "w") as f:
-        output = json.dumps(package, indent=2, sort_keys=True)
-        firstline = True
-        for line in output.split("\n"):
-            if firstline:
-                firstline = False
-            else:
-                f.write("\n")
-            f.write(line.rstrip())
-        f.write("\n")
-    return [package_json]
-
-
 if __name__ == "__main__":
     labels_to_write = read_labels_specs()
 
@@ -309,8 +271,6 @@ if __name__ == "__main__":
     output_files += write_labels_src_files(labels_to_write)
 
     output_files += write_constants_src_files(constants_to_write, schemas_to_write)
-
-    output_files += set_package_json_version()
 
     py_files = [f for f in output_files if f.endswith(".py")]
     subprocess.call(["ruff", "check", "--fix"] + py_files)

--- a/scripts/set_npm_version.py
+++ b/scripts/set_npm_version.py
@@ -1,0 +1,55 @@
+"""
+set_npm_version
+Writes the release version into js/package.json, for the npm publish path only.
+
+Kept out of generate_from_specs.py on purpose. The version is derived from git
+tags, so a tracked value can never match what setuptools-scm computes once a
+release tag is created: the tag is applied to a commit whose package.json was
+written before the tag existed. Regenerating it as part of `make build` made the
+rebuild-from-specs hook fail on every commit after a release. The tracked value
+is a 0.0.0 placeholder; only `make release-npm` sets a real one.
+"""
+
+import json
+import os
+import re
+from importlib.metadata import version as get_version
+
+package_json = os.path.join(os.path.dirname(__file__), "..", "js", "package.json")
+
+
+def pep440_to_npm_semver(version):
+    """Return version if it is an exact X.Y.Z release, else fail.
+
+    setuptools-scm only returns a bare X.Y.Z for a checkout at a release tag.
+    Anything else carries a dev/local suffix and would publish a version that
+    does not correspond to a release.
+    """
+    if not re.match(r"^\d+\.\d+\.\d+$", version):
+        raise SystemExit("Refusing to set npm version from non-release version {!r}. Publish from a checkout at a release tag.".format(version))
+    return version
+
+
+def set_package_json_version():
+    npm_version = pep440_to_npm_semver(get_version("le-utils"))
+
+    with open(package_json, "r") as f:
+        package = json.load(f)
+
+    package["version"] = npm_version
+
+    with open(package_json, "w") as f:
+        output = json.dumps(package, indent=2, sort_keys=True)
+        firstline = True
+        for line in output.split("\n"):
+            if firstline:
+                firstline = False
+            else:
+                f.write("\n")
+            f.write(line.rstrip())
+        f.write("\n")
+    return npm_version
+
+
+if __name__ == "__main__":
+    print("Set js/package.json version to {}".format(set_package_json_version()))


### PR DESCRIPTION
## Summary

Using setuptools-scm means that the version is now dynamic based on the most recent git tag
This broke linting because it would regenerate the npm package version
Fix this by no longer regenerating the npm version except at publish
The committed version is pinned to 0.0.0 - publishing generates and pushes the actual version

## References

First seen: #230 — linting has failed on every PR opened since v0.2.18 was tagged.
Prior workaround: c4cdf70.

## Reviewer guidance

- `scripts/set_npm_version.py:29` — the guard rejects anything that isn't a bare `X.Y.Z`; check that `npm-publish.yml`'s checkout of the release ref actually yields one, or publishing fails closed.
- `Makefile:36` — only `release-npm` sets the version; confirm nothing in the PyPI path (`dist`/`release`) or downstream tooling reads the tracked value.
- `js/package.json:30` — the tracked placeholder is what a git install (`npm install github:learningequality/le-utils`) reports; confirm no consumer installs from git rather than the registry.

## AI usage

Used Claude Code to diagnose the lint failure from the CI logs and write the fix, including splitting the version write into its own script rather than adding a flag to the spec generator. Verified with prek over all files (both normally and under a simulated post-release tag), the test suite, and manual exercise of the version guard.
